### PR TITLE
Add fromMap constructor to RudderProperty

### DIFF
--- a/lib/RudderClient.dart
+++ b/lib/RudderClient.dart
@@ -3,7 +3,7 @@ import 'package:flutter/services.dart';
 import './RudderConfig.dart';
 import './RudderOption.dart';
 import './RudderProperty.dart';
-import './RudderTraitts.dart';
+import './RudderTraits.dart';
 
 class RudderClient {
   /* API for getting RudderClient instance with bare minimum

--- a/lib/RudderClient.dart
+++ b/lib/RudderClient.dart
@@ -1,8 +1,9 @@
+import 'package:flutter/services.dart';
+
 import './RudderConfig.dart';
-import './RudderTraits.dart';
 import './RudderOption.dart';
 import './RudderProperty.dart';
-import 'package:flutter/services.dart';
+import './RudderTraitts.dart';
 
 class RudderClient {
   /* API for getting RudderClient instance with bare minimum

--- a/lib/RudderProperty.dart
+++ b/lib/RudderProperty.dart
@@ -36,4 +36,6 @@ class RudderProperty {
   void putCurrency(String currency) {
     this.__map["currency"] = currency;
   }
+
+  RudderProperty.fromMap(Map<String, dynamic> map) : __map = map;
 }

--- a/lib/RudderProperty.dart
+++ b/lib/RudderProperty.dart
@@ -1,5 +1,6 @@
 class RudderProperty {
-  Map<String, dynamic> __map = new Map();
+  RudderProperty() : __map = Map();
+  Map<String, dynamic> __map;
 
   Map<String, dynamic> getMap() {
     return this.__map;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: rudder_sdk_flutter
-version: 1.0.7
+version: 1.0.8
 description: The RudderStack Flutter SDK allows you to track event data from your app. It can be easily integrated into your Flutter application. After integrating this SDK, you will also send the event data to your preferred analytics destination/s, such as Google Analytics, Amplitude, and more.
 homepage: https://github.com/rudderlabs/rudder-sdk-flutter
 repository: https://github.com/rudderlabs/rudder-sdk-flutter


### PR DESCRIPTION
## Description of the change

RudderProperty is effectively a Map (in fact, it is converted to a map before being passed to native). Other competing libraries simply allow the developer to set all the properties as map. Adding a fromMap constructor reduces the boilerplate code when using this SDK.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix https://github.com/rudderlabs/rudder-sdk-flutter/issues/31

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
