### PR TITLE
Fix/properties desrialization issue

### DIFF
--- a/rudder_plugin/CHANGELOG.md
+++ b/rudder_plugin/CHANGELOG.md
@@ -121,3 +121,6 @@ build()
               
 ### 2.1.0
    Made automatic collection of advertisingId by the Android SDK configurable using the withAutoCollectAdvertId() API
+   
+### 2.1.1
+   Incorporated rudder web plugin 2.1.1

--- a/rudder_plugin/example/lib/main.dart
+++ b/rudder_plugin/example/lib/main.dart
@@ -1,4 +1,3 @@
-import 'dart:ffi';
 
 import 'package:flutter/material.dart';
 import 'package:rudder_sdk_flutter/RudderController.dart';
@@ -39,7 +38,7 @@ class _PlatformChannelState extends State<PlatformChannel> {
     //RudderClient.getInstance("1n0JdVPZTRUIkLXYccrWzZwdGSx",
     //   config: builder.build());
     //2. With RudderConfigBuilder object
-    final String _writeKey = "1pAKRv50y15Ti6UWpYroGJaO0Dj";
+    final String _writeKey = "write_key";
     rudderClient.initialize(_writeKey,
         config: builder.build(), options: options);
 
@@ -51,6 +50,8 @@ class _PlatformChannelState extends State<PlatformChannel> {
     property.put("colour", "red");
     property.put("manufacturer", "hyundai");
     property.put("model", "i20");
+    property.put("marks", [1,2,3,4]);
+    property.put("something nested", [{"nest_2":[76,78], "nest_2_1" : {"nest_2_2": "some val"}},{"string_arr": ["a", "b"]}]);
     RudderOption options = RudderOption();
     options.putIntegration("All", false);
     options.putIntegration("Mixpanel", false);

--- a/rudder_plugin/example/pubspec.yaml
+++ b/rudder_plugin/example/pubspec.yaml
@@ -12,8 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  rudder_sdk_flutter:
-    path: ../
+  rudder_sdk_flutter: ^2.1.1
     # When depending on this package from a real application you should use:
     #   rudder_sdk_flutter: ^x.y.z
     # See https://dart.dev/tools/pub/dependencies#version-constraints

--- a/rudder_plugin/example/pubspec.yaml
+++ b/rudder_plugin/example/pubspec.yaml
@@ -12,7 +12,8 @@ dependencies:
   flutter:
     sdk: flutter
 
-  rudder_sdk_flutter: ^2.1.0
+  rudder_sdk_flutter:
+    path: ../
     # When depending on this package from a real application you should use:
     #   rudder_sdk_flutter: ^x.y.z
     # See https://dart.dev/tools/pub/dependencies#version-constraints

--- a/rudder_plugin/pubspec.yaml
+++ b/rudder_plugin/pubspec.yaml
@@ -1,5 +1,5 @@
 name: rudder_sdk_flutter
-version: 2.1.0
+version: 2.1.1
 description: The RudderStack Flutter SDK allows you to track event data from your app. It can be easily integrated into your Flutter application. After integrating this SDK, you will also send the event data to your preferred analytics destination/s, such as Google Analytics, Amplitude, and more.
 homepage: https://github.com/rudderlabs/rudder-sdk-flutter
 repository: https://github.com/rudderlabs/rudder-sdk-flutter
@@ -17,8 +17,7 @@ dependencies:
   rudder_sdk_flutter_platform_interface: ^2.1.0
   rudder_plugin_android: ^2.1.0
   rudder_plugin_ios: ^2.0.1
-  rudder_plugin_web:
-    path: "../rudder_plugin_web"
+  rudder_plugin_web: ^2.1.1
   logger: ^1.0.0
   intl: ^0.17.0
 

--- a/rudder_plugin/pubspec.yaml
+++ b/rudder_plugin/pubspec.yaml
@@ -17,7 +17,8 @@ dependencies:
   rudder_sdk_flutter_platform_interface: ^2.1.0
   rudder_plugin_android: ^2.1.0
   rudder_plugin_ios: ^2.0.1
-  rudder_plugin_web: ^2.0.0
+  rudder_plugin_web:
+    path: "../rudder_plugin_web"
   logger: ^1.0.0
   intl: ^0.17.0
 

--- a/rudder_plugin_web/CHANGELOG.md
+++ b/rudder_plugin_web/CHANGELOG.md
@@ -3,3 +3,6 @@
 
 ### 2.1.0
    Made automatic collection of advertisingId by the Android SDK configurable using the withAutoCollectAdvertId() API
+   
+### 2.1.1
+   Changes in JS interpolable APIs and adding new serialization structure from Dart to Javascript 

--- a/rudder_plugin_web/lib/internal/web_js.dart
+++ b/rudder_plugin_web/lib/internal/web_js.dart
@@ -1,38 +1,40 @@
 @JS()
 library rudder_analytics.js;
 
+import 'dart:js';
+
 import 'package:js/js.dart';
 // import 'package:rudder_sdk_flutter/RudderLogger.dart';
 
 @JS("rudderanalytics.load")
 external load(
-    String writeKey, String dataPlaneUrl, Map<String, dynamic>? options);
+    String writeKey, String dataPlaneUrl, dynamic options);
 
 @JS("rudderanalytics.setAnonymousId")
 external setAnonymousId(String anonymousId);
 
 @JS("rudderanalytics.identify")
 external identify(
-    String userId, Map<String, dynamic>? traits, Map<String, dynamic>? options);
+    String userId, dynamic traits, dynamic options);
 
 @JS("rudderanalytics.page")
-external page(String? category, String name, Map<String, dynamic>? properties,
-    Map<String, dynamic>? options);
+external page(String? category, String name, dynamic properties,
+    dynamic options);
 
 @JS("rudderanalytics.track")
-external track(String event, Map<String, dynamic>? properties,
-    Map<String, dynamic>? options);
+external track(String event, dynamic properties,
+    dynamic options);
 
 @JS("rudderanalytics.alias")
 external alias(
     String to, //Denotes the new identifier of the user.
     String? from,
     //Denotes the old identifier which will be an alias for the to parameter.
-    Map<String, dynamic>? options);
+    dynamic options);
 
 @JS("rudderanalytics.group")
-external group(String groupId, Map<String, dynamic>? traits,
-    Map<String, dynamic>? options);
+external group(String groupId, dynamic traits,
+    dynamic options);
 
 @JS("rudderanalytics.reset")
 external reset();
@@ -41,4 +43,4 @@ external reset();
 external String? getAnonymousId();
 
 @JS("rudderanalytics.getUserTraits")
-external Map<String, dynamic>? getUserTraits();
+external dynamic getUserTraits();

--- a/rudder_plugin_web/lib/rudder_plugin_web.dart
+++ b/rudder_plugin_web/lib/rudder_plugin_web.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:js';
 import 'package:js/js_util.dart' as js;
 // In order to *not* need this ignore, consider extracting the "web" version
 // of your plugin as a separate package, instead of inlining it in the same
@@ -127,8 +126,6 @@ class RudderSdkFlutterWeb extends RudderSdkPlatform {
       // final encode = JsObject.jsify(object);
       if(object is Map) {
         final encode = mapToJSObj(object);
-        // final encode = object;
-        print(encode);
         return encode;
       }
     }
@@ -148,13 +145,6 @@ class RudderSdkFlutterWeb extends RudderSdkPlatform {
   static dynamic _iterableToJSArray(Iterable<dynamic> array){
     var preparedArray = array.map((element) => element is Map? mapToJSObj(element) :
     element is Iterable? _iterableToJSArray(element) : element);
-     /*var arrayOutput = JsArray();
-    var index = 0;
-    array.forEach((element) {
-      dynamic value = element is Map? mapToJSObj(element) : element is Iterable? _iterableToJSArray(element) : element;
-      arrayOutput[index ++] =  value;
-    });
-    return arrayOutput;*/
     return [...preparedArray];
   }
 }

--- a/rudder_plugin_web/pubspec.yaml
+++ b/rudder_plugin_web/pubspec.yaml
@@ -1,5 +1,5 @@
 name: rudder_plugin_web
-version: 2.1.0
+version: 2.1.1
 description: The RudderStack Flutter SDK allows you to track event data from your app. It can be easily integrated into your Flutter application. After integrating this SDK, you will also send the event data to your preferred analytics destination/s, such as Google Analytics, Amplitude, and more.
 homepage: https://github.com/rudderlabs/rudder-sdk-flutter
 repository: https://github.com/rudderlabs/rudder-sdk-flutter
@@ -31,13 +31,6 @@ flutter:
   plugin:
     implements: rudder_sdk_flutter
     platforms:
-      #      android:
-      #        package: com.rudderstack.sdk.flutter
-      #        pluginClass: RudderSdkFlutterPlugin
-      #      ios:
-      #        pluginClass: RudderSdkFlutterPlugin
       web:
         pluginClass: RudderSdkFlutterWeb
         fileName: rudder_plugin_web.dart
-#  assets:
-#    - assets/rudder_analytics.js


### PR DESCRIPTION
## Properties and other Maps were not deserialised by the JS SDK, when sent through dart.

> Properties sent over from flutter didn't make it through JS SDK.
Notion link - [link](https://www.notion.so/rudderstacks/When-app-is-sending-properties-to-track-event-properties-at-recorded-event-are-always-empty-objects-8a36fc787c71424f992a9a054450682e)

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
