### PR TITLE
fix: build gradle minsdkversion to 19

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ android {
   compileSdkVersion 29
 
   defaultConfig {
-    minSdkVersion 16
+    minSdkVersion 19
   }
   lintOptions {
     disable 'InvalidPackage'
@@ -38,6 +38,6 @@ android {
 }
 
 dependencies {
-  implementation 'com.rudderstack.android.sdk:core:1.+'
+  implementation 'com.rudderstack.android.sdk:core:1.6.1'
   implementation 'com.google.code.gson:gson:2.8.6'
 }


### PR DESCRIPTION
## Description of the change

Can't compile the package with the latest version of `com.rudderstack.android.sdk:core` (1.6.1), this PR fix this problem by set the version to 1.6.1 and the `minSdkVersion` to 19.

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklists

### Development

- [X] Lint rules pass locally
- [X] The code changed/added as part of this pull request has been covered with tests
- [X] All tests related to the changed code pass in development

### Code review 

- [X]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [X] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
