### PR TITLE
feat: made deviceId collection configurable and de-coupled anonymousid and deviceId

### DIFF
--- a/packages/example/ios/Podfile
+++ b/packages/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-platform :ios, '11.0'
+platform :ios, '12.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/packages/example/ios/Podfile.lock
+++ b/packages/example/ios/Podfile.lock
@@ -100,7 +100,6 @@ PODS:
     - GoogleUtilities/Logger
   - GoogleUtilities/UserDefaults (7.11.5):
     - GoogleUtilities/Logger
-  - Leanplum-iOS-SDK (4.0.0)
   - MetricsReporter (1.0.0):
     - RudderKit (~> 1.4.0)
   - nanopb (2.30909.0):
@@ -129,9 +128,6 @@ PODS:
   - Rudder-Firebase (3.0.0):
     - FirebaseAnalytics (= 10.3.0)
     - Rudder (~> 1.8)
-  - Rudder-Leanplum (1.0.2):
-    - Leanplum-iOS-SDK (= 4.0.0)
-    - Rudder (~> 1.0)
   - rudder_integration_adjust_flutter (1.0.1):
     - Flutter
     - Rudder-Adjust (= 1.0.0)
@@ -156,10 +152,6 @@ PODS:
     - Flutter
     - Rudder-Firebase (= 3.0.0)
     - rudder_plugin_ios
-  - rudder_integration_leanplum_flutter (1.0.1):
-    - Flutter
-    - Rudder-Leanplum (= 1.0.2)
-    - rudder_plugin_ios
   - rudder_plugin_ios (0.0.1):
     - Flutter
     - Rudder (< 2.0.0, >= 1.9.1)
@@ -176,7 +168,6 @@ DEPENDENCIES:
   - rudder_integration_appsflyer_flutter (from `.symlinks/plugins/rudder_integration_appsflyer_flutter/ios`)
   - rudder_integration_braze_flutter (from `.symlinks/plugins/rudder_integration_braze_flutter/ios`)
   - rudder_integration_firebase_flutter (from `.symlinks/plugins/rudder_integration_firebase_flutter/ios`)
-  - rudder_integration_leanplum_flutter (from `.symlinks/plugins/rudder_integration_leanplum_flutter/ios`)
   - rudder_plugin_ios (from `.symlinks/plugins/rudder_plugin_ios/ios`)
 
 SPEC REPOS:
@@ -192,7 +183,6 @@ SPEC REPOS:
     - FirebaseInstallations
     - GoogleAppMeasurement
     - GoogleUtilities
-    - Leanplum-iOS-SDK
     - MetricsReporter
     - nanopb
     - PromisesObjC
@@ -203,7 +193,6 @@ SPEC REPOS:
     - Rudder-Appsflyer
     - Rudder-Braze
     - Rudder-Firebase
-    - Rudder-Leanplum
     - RudderKit
     - SDWebImage
 
@@ -222,8 +211,6 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/rudder_integration_braze_flutter/ios"
   rudder_integration_firebase_flutter:
     :path: ".symlinks/plugins/rudder_integration_firebase_flutter/ios"
-  rudder_integration_leanplum_flutter:
-    :path: ".symlinks/plugins/rudder_integration_leanplum_flutter/ios"
   rudder_plugin_ios:
     :path: ".symlinks/plugins/rudder_plugin_ios/ios"
 
@@ -240,7 +227,6 @@ SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   GoogleAppMeasurement: c7d6fff39bf2d829587d74088d582e32d75133c3
   GoogleUtilities: 13e2c67ede716b8741c7989e26893d151b2b2084
-  Leanplum-iOS-SDK: 8115f65d185eb94d94c4ab08176dfcb4a8b97926
   MetricsReporter: 35d1a8e62cd99e1434bc8fdd06bf2baf7cb23e42
   nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
   PromisesObjC: c50d2056b5253dadbd6c2bea79b0674bd5a52fa4
@@ -251,14 +237,12 @@ SPEC CHECKSUMS:
   Rudder-Appsflyer: b19834ae8d933444411813556e0fe70a33df224a
   Rudder-Braze: e58e0e8163a2dcf0d45ec2d12bdb0ec3329c3681
   Rudder-Firebase: 9f061bf3c23900e1a8f32f8b079ae17e04874f17
-  Rudder-Leanplum: e2c9ffa48ea227c3574998afa1e287061ad042ee
   rudder_integration_adjust_flutter: 7b9b8794548490bd032937966ebde20172b2809b
   rudder_integration_amplitude_flutter: 0c85fc19b9f3b4f33df87b60fa80dac0c01dbd36
   rudder_integration_appcenter_flutter: b9c8d7faec570e3a22b7fc7236e4da21a243d4f9
   rudder_integration_appsflyer_flutter: 4736dc267dd6e8b3e7321e4999ed1bb751b9ad59
   rudder_integration_braze_flutter: ddc8cb4214059122d2f7f6f2aff5772d3fb2e5fd
   rudder_integration_firebase_flutter: 2406b968e85e4a3175b64ccc8f8de98eca3b3d2e
-  rudder_integration_leanplum_flutter: c6e83564dc7c1a96cec8b97c6e75f9b3c1958c91
   rudder_plugin_ios: aa27daa46baaa91581ac5e74eb75ab1783a76690
   RudderKit: f272f9872183946452ac94cd7bb2244a71e6ca8f
   SDWebImage: 750adf017a315a280c60fde706ab1e552a3ae4e9

--- a/packages/example/ios/Podfile.lock
+++ b/packages/example/ios/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - Adjust (4.33.6):
-    - Adjust/Core (= 4.33.6)
-  - Adjust/Core (4.33.6)
+  - Adjust (4.34.1):
+    - Adjust/Core (= 4.34.1)
+  - Adjust/Core (4.34.1)
   - Amplitude (7.2.2)
   - Appboy-iOS-SDK (4.4.2):
     - Appboy-iOS-SDK/UI (= 4.4.2)
@@ -49,13 +49,13 @@ PODS:
     - GoogleUtilities/Network (~> 7.8)
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseCore (10.13.0):
+  - FirebaseCore (10.14.0):
     - FirebaseCoreInternal (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/Logger (~> 7.8)
-  - FirebaseCoreInternal (10.13.0):
+  - FirebaseCoreInternal (10.14.0):
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
-  - FirebaseInstallations (10.13.0):
+  - FirebaseInstallations (10.14.0):
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
@@ -101,13 +101,16 @@ PODS:
   - GoogleUtilities/UserDefaults (7.11.5):
     - GoogleUtilities/Logger
   - Leanplum-iOS-SDK (4.0.0)
+  - MetricsReporter (1.0.0):
+    - RudderKit (~> 1.4.0)
   - nanopb (2.30909.0):
     - nanopb/decode (= 2.30909.0)
     - nanopb/encode (= 2.30909.0)
   - nanopb/decode (2.30909.0)
   - nanopb/encode (2.30909.0)
   - PromisesObjC (2.3.1)
-  - Rudder (1.17.0)
+  - Rudder (1.19.1):
+    - MetricsReporter (= 1.0.0)
   - Rudder-Adjust (1.0.0):
     - Adjust
     - Rudder
@@ -159,7 +162,8 @@ PODS:
     - rudder_plugin_ios
   - rudder_plugin_ios (0.0.1):
     - Flutter
-    - Rudder (~> 1.17)
+    - Rudder (< 2.0.0, >= 1.9.1)
+  - RudderKit (1.4.0)
   - SDWebImage (5.17.0):
     - SDWebImage/Core (= 5.17.0)
   - SDWebImage/Core (5.17.0)
@@ -189,6 +193,7 @@ SPEC REPOS:
     - GoogleAppMeasurement
     - GoogleUtilities
     - Leanplum-iOS-SDK
+    - MetricsReporter
     - nanopb
     - PromisesObjC
     - Rudder
@@ -199,6 +204,7 @@ SPEC REPOS:
     - Rudder-Braze
     - Rudder-Firebase
     - Rudder-Leanplum
+    - RudderKit
     - SDWebImage
 
 EXTERNAL SOURCES:
@@ -222,22 +228,23 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/rudder_plugin_ios/ios"
 
 SPEC CHECKSUMS:
-  Adjust: c3b6c3734928a617fefce81dc223fd5f104162be
+  Adjust: 1410b6ccbce29c91b8e88064186a7b103244fa43
   Amplitude: 517cdc7c485bda64b685174426ecbf17746eb16a
   Appboy-iOS-SDK: 4a7dfe908639da81e5e85849355f6066b58b4cc6
   AppCenter: a4070ec3d4418b5539067a51f57155012e486ebd
   AppsFlyerFramework: 75e2e46970e520c88b0456dc6fae98c51b36163a
   FirebaseAnalytics: 036232b6a1e2918e5f67572417be1173576245f3
-  FirebaseCore: 9948a31ff2c6cf323f9b040068201a95d271b68d
-  FirebaseCoreInternal: b342e37cd4f5b4454ec34308f073420e7920858e
-  FirebaseInstallations: b28af1b9f997f1a799efe818c94695a3728c352f
+  FirebaseCore: 6fc17ac9f03509d51c131298aacb3ee5698b4f02
+  FirebaseCoreInternal: d558159ee6cc4b823c2296ecc193de9f6d9a5bb3
+  FirebaseInstallations: f672b1eda64e6381c21d424a2f680a943fd83f3b
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   GoogleAppMeasurement: c7d6fff39bf2d829587d74088d582e32d75133c3
   GoogleUtilities: 13e2c67ede716b8741c7989e26893d151b2b2084
   Leanplum-iOS-SDK: 8115f65d185eb94d94c4ab08176dfcb4a8b97926
+  MetricsReporter: 35d1a8e62cd99e1434bc8fdd06bf2baf7cb23e42
   nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
   PromisesObjC: c50d2056b5253dadbd6c2bea79b0674bd5a52fa4
-  Rudder: 3f4ab09638452282a22b96a388b54132dcd3fca8
+  Rudder: 187a8fc060057605b6e78fb8077b4d989943d804
   Rudder-Adjust: 5f14011c8f7237d80a96a10655ac03ebf832bcc4
   Rudder-Amplitude: f845cc125a1a58d4de6155391a2b0392815ae898
   Rudder-AppCenter: 9eca9241e3707a0e9610714dd91dc8da4bae7e1f
@@ -252,8 +259,10 @@ SPEC CHECKSUMS:
   rudder_integration_braze_flutter: ddc8cb4214059122d2f7f6f2aff5772d3fb2e5fd
   rudder_integration_firebase_flutter: 2406b968e85e4a3175b64ccc8f8de98eca3b3d2e
   rudder_integration_leanplum_flutter: c6e83564dc7c1a96cec8b97c6e75f9b3c1958c91
-  rudder_plugin_ios: 5041dd85f17244e737254b78bb48dff412b18db9
+  rudder_plugin_ios: aa27daa46baaa91581ac5e74eb75ab1783a76690
+  RudderKit: f272f9872183946452ac94cd7bb2244a71e6ca8f
   SDWebImage: 750adf017a315a280c60fde706ab1e552a3ae4e9
-PODFILE CHECKSUM: 8ac12c04bf01db6d6e9ee903496e5f7eda779c7c
+
+PODFILE CHECKSUM: 5265e733c786a5987c9aa8f08d969fb3ef180aca
 
 COCOAPODS: 1.12.0

--- a/packages/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/example/ios/Runner.xcodeproj/project.pbxproj
@@ -9,11 +9,11 @@
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
-		4E89A26B62B7835DF0CDAC7B /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9CB9B98746F3B7534680D554 /* Pods_Runner.framework */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		D5314B56906AA2F8DF6A803A /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73C9EDE32D5C23C3363B1BA9 /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -32,7 +32,10 @@
 /* Begin PBXFileReference section */
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
+		2921FBB6205F79E9D2E63A96 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		3B915C980EF17DFB6193A6C6 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		73C9EDE32D5C23C3363B1BA9 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
@@ -43,10 +46,7 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		9CB9B98746F3B7534680D554 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		AD6F1E9CF90488F5422C2D30 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
-		C5502EBFB4872214C8EA650C /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
-		F77DDD2900261BDB431C0A14 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		F60C5971659B706A94194B37 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -54,19 +54,27 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4E89A26B62B7835DF0CDAC7B /* Pods_Runner.framework in Frameworks */,
+				D5314B56906AA2F8DF6A803A /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		08192186B5154080E8A22385 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				73C9EDE32D5C23C3363B1BA9 /* Pods_Runner.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		8407D258E6E03BD7140000D2 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				F77DDD2900261BDB431C0A14 /* Pods-Runner.debug.xcconfig */,
-				AD6F1E9CF90488F5422C2D30 /* Pods-Runner.release.xcconfig */,
-				C5502EBFB4872214C8EA650C /* Pods-Runner.profile.xcconfig */,
+				2921FBB6205F79E9D2E63A96 /* Pods-Runner.debug.xcconfig */,
+				3B915C980EF17DFB6193A6C6 /* Pods-Runner.release.xcconfig */,
+				F60C5971659B706A94194B37 /* Pods-Runner.profile.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -89,7 +97,7 @@
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
 				8407D258E6E03BD7140000D2 /* Pods */,
-				9E3962E683A4D560B54FDC78 /* Frameworks */,
+				08192186B5154080E8A22385 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -116,14 +124,6 @@
 			path = Runner;
 			sourceTree = "<group>";
 		};
-		9E3962E683A4D560B54FDC78 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				9CB9B98746F3B7534680D554 /* Pods_Runner.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -131,14 +131,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
-				B0451E90C7DAD8F3A1AB1376 /* [CP] Check Pods Manifest.lock */,
+				466EE0C8A31EECFF71D54DBF /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
-				01584D09BD328200E817DCD5 /* [CP] Copy Pods Resources */,
+				A73092A518BC468777DFD42D /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -197,24 +197,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		01584D09BD328200E817DCD5 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -231,22 +213,7 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
 		};
-		9740EEB61CF901F6004384FC /* Run Script */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Run Script";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build\n";
-		};
-		B0451E90C7DAD8F3A1AB1376 /* [CP] Check Pods Manifest.lock */ = {
+		466EE0C8A31EECFF71D54DBF /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -266,6 +233,38 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		9740EEB61CF901F6004384FC /* Run Script */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Run Script";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build\n";
+		};
+		A73092A518BC468777DFD42D /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -364,7 +363,7 @@
 				DEVELOPMENT_TEAM = WPX9KRKA8B;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -497,7 +496,7 @@
 				DEVELOPMENT_TEAM = WPX9KRKA8B;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -524,7 +523,7 @@
 				DEVELOPMENT_TEAM = WPX9KRKA8B;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/packages/example/lib/home_screen.dart
+++ b/packages/example/lib/home_screen.dart
@@ -37,7 +37,8 @@ class HomeScreenState extends State<HomeScreen> {
   }
 
   void __initialize() {
-    MobileConfig mc = MobileConfig(autoCollectAdvertId: false);
+    MobileConfig mc =
+        MobileConfig(autoCollectAdvertId: false, collectDeviceId: false);
     RudderConfigBuilder builder = RudderConfigBuilder();
     builder.withFactory(RudderIntegrationAppcenterFlutter());
     builder.withFactory(RudderIntegrationFirebaseFlutter());
@@ -112,7 +113,7 @@ class HomeScreenState extends State<HomeScreen> {
   }
 
   void __reset() {
-    rudderClient.reset();
+    rudderClient.reset(clearAnonymousId: true);
     setOutput("reset");
   }
 

--- a/packages/example/pubspec.lock
+++ b/packages/example/pubspec.lock
@@ -370,13 +370,6 @@ packages:
       relative: true
     source: path
     version: "2.0.6"
-  rudder_integration_leanplum_flutter:
-    dependency: "direct main"
-    description:
-      path: "../integrations/rudder_integration_leanplum_flutter"
-      relative: true
-    source: path
-    version: "1.0.7"
   rudder_plugin_android:
     dependency: "direct overridden"
     description:

--- a/packages/example/pubspec.lock
+++ b/packages/example/pubspec.lock
@@ -334,84 +334,84 @@ packages:
       path: "../integrations/rudder_integration_adjust_flutter"
       relative: true
     source: path
-    version: "1.0.5"
+    version: "1.0.7"
   rudder_integration_amplitude_flutter:
     dependency: "direct main"
     description:
       path: "../integrations/rudder_integration_amplitude_flutter"
       relative: true
     source: path
-    version: "1.0.5"
+    version: "1.0.7"
   rudder_integration_appcenter_flutter:
     dependency: "direct main"
     description:
       path: "../integrations/rudder_integration_appcenter_flutter"
       relative: true
     source: path
-    version: "1.1.5"
+    version: "1.1.7"
   rudder_integration_appsflyer_flutter:
     dependency: "direct main"
     description:
       path: "../integrations/rudder_integration_appsflyer_flutter"
       relative: true
     source: path
-    version: "1.1.2"
+    version: "1.1.4"
   rudder_integration_braze_flutter:
     dependency: "direct main"
     description:
       path: "../integrations/rudder_integration_braze_flutter"
       relative: true
     source: path
-    version: "1.0.5"
+    version: "1.0.7"
   rudder_integration_firebase_flutter:
     dependency: "direct main"
     description:
       path: "../integrations/rudder_integration_firebase_flutter"
       relative: true
     source: path
-    version: "2.0.4"
+    version: "2.0.6"
   rudder_integration_leanplum_flutter:
     dependency: "direct main"
     description:
       path: "../integrations/rudder_integration_leanplum_flutter"
       relative: true
     source: path
-    version: "1.0.5"
+    version: "1.0.7"
   rudder_plugin_android:
     dependency: "direct overridden"
     description:
       path: "../plugins/rudder_plugin_android"
       relative: true
     source: path
-    version: "2.2.2"
+    version: "2.3.0"
   rudder_plugin_ios:
     dependency: "direct overridden"
     description:
       path: "../plugins/rudder_plugin_ios"
       relative: true
     source: path
-    version: "2.2.2"
+    version: "2.3.0"
   rudder_plugin_web:
     dependency: "direct overridden"
     description:
       path: "../plugins/rudder_plugin_web"
       relative: true
     source: path
-    version: "2.2.3"
+    version: "2.3.1"
   rudder_sdk_flutter:
     dependency: "direct main"
     description:
       path: "../plugins/rudder_plugin"
       relative: true
     source: path
-    version: "2.3.3"
+    version: "2.4.1"
   rudder_sdk_flutter_platform_interface:
     dependency: "direct overridden"
     description:
       path: "../plugins/rudder_plugin_interface"
       relative: true
     source: path
-    version: "2.3.1"
+    version: "2.4.0"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/packages/example/pubspec.yaml
+++ b/packages/example/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   rudder_integration_braze_flutter: ^1.0.7
   rudder_integration_appcenter_flutter: ^1.1.7
   rudder_integration_adjust_flutter: ^1.0.7
-  rudder_integration_leanplum_flutter: ^1.0.7
+  # rudder_integration_leanplum_flutter: ^1.0.7
   rudder_integration_appsflyer_flutter: ^1.1.4
     # When depending on this package from a real application you should use:
     #   rudder_sdk_flutter: ^x.y.z

--- a/packages/integrations/rudder_integration_adjust_flutter/pubspec.lock
+++ b/packages/integrations/rudder_integration_adjust_flutter/pubspec.lock
@@ -342,35 +342,35 @@ packages:
       path: "../../plugins/rudder_plugin_android"
       relative: true
     source: path
-    version: "2.2.2"
+    version: "2.3.0"
   rudder_plugin_ios:
     dependency: "direct overridden"
     description:
       path: "../../plugins/rudder_plugin_ios"
       relative: true
     source: path
-    version: "2.2.2"
+    version: "2.3.0"
   rudder_plugin_web:
     dependency: "direct overridden"
     description:
       path: "../../plugins/rudder_plugin_web"
       relative: true
     source: path
-    version: "2.2.3"
+    version: "2.3.1"
   rudder_sdk_flutter:
     dependency: "direct main"
     description:
       path: "../../plugins/rudder_plugin"
       relative: true
     source: path
-    version: "2.3.3"
+    version: "2.4.1"
   rudder_sdk_flutter_platform_interface:
     dependency: "direct main"
     description:
       path: "../../plugins/rudder_plugin_interface"
       relative: true
     source: path
-    version: "2.3.1"
+    version: "2.4.0"
   shelf:
     dependency: transitive
     description:

--- a/packages/integrations/rudder_integration_amplitude_flutter/pubspec.lock
+++ b/packages/integrations/rudder_integration_amplitude_flutter/pubspec.lock
@@ -342,35 +342,35 @@ packages:
       path: "../../plugins/rudder_plugin_android"
       relative: true
     source: path
-    version: "2.2.2"
+    version: "2.3.0"
   rudder_plugin_ios:
     dependency: "direct overridden"
     description:
       path: "../../plugins/rudder_plugin_ios"
       relative: true
     source: path
-    version: "2.2.2"
+    version: "2.3.0"
   rudder_plugin_web:
     dependency: "direct overridden"
     description:
       path: "../../plugins/rudder_plugin_web"
       relative: true
     source: path
-    version: "2.2.3"
+    version: "2.3.1"
   rudder_sdk_flutter:
     dependency: "direct main"
     description:
       path: "../../plugins/rudder_plugin"
       relative: true
     source: path
-    version: "2.3.3"
+    version: "2.4.1"
   rudder_sdk_flutter_platform_interface:
     dependency: "direct main"
     description:
       path: "../../plugins/rudder_plugin_interface"
       relative: true
     source: path
-    version: "2.3.1"
+    version: "2.4.0"
   shelf:
     dependency: transitive
     description:

--- a/packages/integrations/rudder_integration_appcenter_flutter/pubspec.lock
+++ b/packages/integrations/rudder_integration_appcenter_flutter/pubspec.lock
@@ -342,35 +342,35 @@ packages:
       path: "../../plugins/rudder_plugin_android"
       relative: true
     source: path
-    version: "2.2.2"
+    version: "2.3.0"
   rudder_plugin_ios:
     dependency: "direct overridden"
     description:
       path: "../../plugins/rudder_plugin_ios"
       relative: true
     source: path
-    version: "2.2.2"
+    version: "2.3.0"
   rudder_plugin_web:
     dependency: "direct overridden"
     description:
       path: "../../plugins/rudder_plugin_web"
       relative: true
     source: path
-    version: "2.2.3"
+    version: "2.3.1"
   rudder_sdk_flutter:
     dependency: "direct main"
     description:
       path: "../../plugins/rudder_plugin"
       relative: true
     source: path
-    version: "2.3.3"
+    version: "2.4.1"
   rudder_sdk_flutter_platform_interface:
     dependency: "direct main"
     description:
       path: "../../plugins/rudder_plugin_interface"
       relative: true
     source: path
-    version: "2.3.1"
+    version: "2.4.0"
   shelf:
     dependency: transitive
     description:

--- a/packages/integrations/rudder_integration_braze_flutter/pubspec.lock
+++ b/packages/integrations/rudder_integration_braze_flutter/pubspec.lock
@@ -342,35 +342,35 @@ packages:
       path: "../../plugins/rudder_plugin_android"
       relative: true
     source: path
-    version: "2.2.2"
+    version: "2.3.0"
   rudder_plugin_ios:
     dependency: "direct overridden"
     description:
       path: "../../plugins/rudder_plugin_ios"
       relative: true
     source: path
-    version: "2.2.2"
+    version: "2.3.0"
   rudder_plugin_web:
     dependency: "direct overridden"
     description:
       path: "../../plugins/rudder_plugin_web"
       relative: true
     source: path
-    version: "2.2.3"
+    version: "2.3.1"
   rudder_sdk_flutter:
     dependency: "direct main"
     description:
       path: "../../plugins/rudder_plugin"
       relative: true
     source: path
-    version: "2.3.3"
+    version: "2.4.1"
   rudder_sdk_flutter_platform_interface:
     dependency: "direct main"
     description:
       path: "../../plugins/rudder_plugin_interface"
       relative: true
     source: path
-    version: "2.3.1"
+    version: "2.4.0"
   shelf:
     dependency: transitive
     description:

--- a/packages/integrations/rudder_integration_firebase_flutter/pubspec.lock
+++ b/packages/integrations/rudder_integration_firebase_flutter/pubspec.lock
@@ -342,35 +342,35 @@ packages:
       path: "../../plugins/rudder_plugin_android"
       relative: true
     source: path
-    version: "2.2.2"
+    version: "2.3.0"
   rudder_plugin_ios:
     dependency: "direct overridden"
     description:
       path: "../../plugins/rudder_plugin_ios"
       relative: true
     source: path
-    version: "2.2.2"
+    version: "2.3.0"
   rudder_plugin_web:
     dependency: "direct overridden"
     description:
       path: "../../plugins/rudder_plugin_web"
       relative: true
     source: path
-    version: "2.2.3"
+    version: "2.3.1"
   rudder_sdk_flutter:
     dependency: "direct main"
     description:
       path: "../../plugins/rudder_plugin"
       relative: true
     source: path
-    version: "2.3.3"
+    version: "2.4.1"
   rudder_sdk_flutter_platform_interface:
     dependency: "direct main"
     description:
       path: "../../plugins/rudder_plugin_interface"
       relative: true
     source: path
-    version: "2.3.1"
+    version: "2.4.0"
   shelf:
     dependency: transitive
     description:

--- a/packages/integrations/rudder_integration_leanplum_flutter/pubspec.lock
+++ b/packages/integrations/rudder_integration_leanplum_flutter/pubspec.lock
@@ -342,35 +342,35 @@ packages:
       path: "../../plugins/rudder_plugin_android"
       relative: true
     source: path
-    version: "2.2.2"
+    version: "2.3.0"
   rudder_plugin_ios:
     dependency: "direct overridden"
     description:
       path: "../../plugins/rudder_plugin_ios"
       relative: true
     source: path
-    version: "2.2.2"
+    version: "2.3.0"
   rudder_plugin_web:
     dependency: "direct overridden"
     description:
       path: "../../plugins/rudder_plugin_web"
       relative: true
     source: path
-    version: "2.2.3"
+    version: "2.3.1"
   rudder_sdk_flutter:
     dependency: "direct main"
     description:
       path: "../../plugins/rudder_plugin"
       relative: true
     source: path
-    version: "2.3.3"
+    version: "2.4.1"
   rudder_sdk_flutter_platform_interface:
     dependency: "direct main"
     description:
       path: "../../plugins/rudder_plugin_interface"
       relative: true
     source: path
-    version: "2.3.1"
+    version: "2.4.0"
   shelf:
     dependency: transitive
     description:

--- a/packages/plugins/rudder_plugin/README.md
+++ b/packages/plugins/rudder_plugin/README.md
@@ -103,6 +103,7 @@ check [the documentation page](https://docs.rudderstack.com/rudderstack-sdk-inte
 
 ## List of Features
 - Data Residency, Custom Context from version `2.4.0`
+- Configurable Collection of Device Id from version `2.5.0`
 
 ## Contact Us
 

--- a/packages/plugins/rudder_plugin/lib/RudderController.dart
+++ b/packages/plugins/rudder_plugin/lib/RudderController.dart
@@ -43,8 +43,8 @@ class RudderController {
     RudderSdkPlatform.instance.alias(newId, options: options);
   }
 
-  void reset() {
-    RudderSdkPlatform.instance.reset();
+  void reset({bool clearAnonymousId = false}) {
+    RudderSdkPlatform.instance.reset(clearAnonymousId: clearAnonymousId);
   }
 
   void optOut(bool optOut) {

--- a/packages/plugins/rudder_plugin/pubspec.lock
+++ b/packages/plugins/rudder_plugin/pubspec.lock
@@ -342,28 +342,28 @@ packages:
       path: "../rudder_plugin_android"
       relative: true
     source: path
-    version: "2.2.2"
+    version: "2.3.0"
   rudder_plugin_ios:
     dependency: "direct main"
     description:
       path: "../rudder_plugin_ios"
       relative: true
     source: path
-    version: "2.2.2"
+    version: "2.3.0"
   rudder_plugin_web:
     dependency: "direct main"
     description:
       path: "../rudder_plugin_web"
       relative: true
     source: path
-    version: "2.2.3"
+    version: "2.3.1"
   rudder_sdk_flutter_platform_interface:
     dependency: "direct main"
     description:
       path: "../rudder_plugin_interface"
       relative: true
     source: path
-    version: "2.3.1"
+    version: "2.4.0"
   shelf:
     dependency: transitive
     description:

--- a/packages/plugins/rudder_plugin_android/android/build.gradle
+++ b/packages/plugins/rudder_plugin_android/android/build.gradle
@@ -38,6 +38,6 @@ android {
 }
 
 dependencies {
-    implementation 'com.rudderstack.android.sdk:core:[1.17.0, 2.0.0)'
+    implementation 'com.rudderstack.android.sdk:core:[1.18.0, 2.0.0)'
     implementation 'com.google.code.gson:gson:2.8.6'
 }

--- a/packages/plugins/rudder_plugin_android/android/src/main/java/com/rudderstack/sdk/flutter/RudderSdkFlutterPlugin.java
+++ b/packages/plugins/rudder_plugin_android/android/src/main/java/com/rudderstack/sdk/flutter/RudderSdkFlutterPlugin.java
@@ -168,7 +168,12 @@ public class RudderSdkFlutterPlugin implements FlutterPlugin, MethodCallHandler 
       rudderClient.alias((String) argumentsMap.get("newId"), options);
       return;
     } else if (call.method.equals("reset")) {
-      rudderClient.reset();
+      HashMap<String, Object> argumentsMap = (HashMap<String, Object>) call.arguments;
+      if (argumentsMap.containsKey("clearAnonymousId")) {
+        rudderClient.reset((boolean) argumentsMap.get("clearAnonymousId"));
+      } else {
+        rudderClient.reset();
+      }
       return;
     } else if (call.method.equals("optOut")) {
       HashMap<String, Object> argumentsMap = (HashMap<String, Object>) call.arguments;

--- a/packages/plugins/rudder_plugin_android/android/src/main/java/com/rudderstack/sdk/flutter/RudderSdkFlutterPlugin.java
+++ b/packages/plugins/rudder_plugin_android/android/src/main/java/com/rudderstack/sdk/flutter/RudderSdkFlutterPlugin.java
@@ -227,6 +227,7 @@ public class RudderSdkFlutterPlugin implements FlutterPlugin, MethodCallHandler 
         .withLogLevel((Integer) configMap.get("logLevel"))
         .withSleepCount((Integer) configMap.get("sleepTimeOut"))
         .withAutoCollectAdvertId((Boolean) configMap.get("autoCollectAdvertId"))
+        .withCollectDeviceId((Boolean) configMap.get("collectDeviceId"))
         .withTrackLifecycleEvents((Boolean) configMap.get("trackLifecycleEvents"))
         .withRecordScreenViews((Boolean) configMap.get("recordScreenViews"))
         .withControlPlaneUrl((String) configMap.get("controlPlaneUrl"));

--- a/packages/plugins/rudder_plugin_android/lib/rudder_plugin_android.dart
+++ b/packages/plugins/rudder_plugin_android/lib/rudder_plugin_android.dart
@@ -113,8 +113,10 @@ class RudderSdkFlutterAndroid extends RudderSdkPlatform {
   }
 
   @override
-  void reset() {
-    _platformChannel.invokeMethod("reset");
+  void reset({bool clearAnonymousId = false}) {
+    Map<String, dynamic> params = {};
+    params["clearAnonymousId"] = clearAnonymousId;
+    _platformChannel.invokeMethod("reset", params);
   }
 
   @override

--- a/packages/plugins/rudder_plugin_android/pubspec.lock
+++ b/packages/plugins/rudder_plugin_android/pubspec.lock
@@ -337,7 +337,7 @@ packages:
       path: "../rudder_plugin_interface"
       relative: true
     source: path
-    version: "2.3.1"
+    version: "2.4.0"
   shelf:
     dependency: transitive
     description:

--- a/packages/plugins/rudder_plugin_interface/lib/rudder_sdk_platform.dart
+++ b/packages/plugins/rudder_plugin_interface/lib/rudder_sdk_platform.dart
@@ -61,7 +61,7 @@ abstract class RudderSdkPlatform extends PlatformInterface {
     throw UnimplementedError('load(String writeKey, String dataPlaneUrl) has not been implemented.');
   }*/
 
-  void reset() {
+  void reset({bool clearAnonymousId = false}) {
     throw UnimplementedError('reset() has not been implemented.');
   }
 

--- a/packages/plugins/rudder_plugin_interface/lib/src/constants.dart
+++ b/packages/plugins/rudder_plugin_interface/lib/src/constants.dart
@@ -27,6 +27,9 @@ class Constants {
   // whether the SDK should automatically collect the advertisingId
   static const bool AUTO_COLLECT_ADVERT_ID = false;
 
+  // whether the SDK should send deviceId as part of the event payload
+  static const bool COLLECT_DEVICE_ID = true;
+
   // whether we should trackLifecycle events
   static const bool TRACK_LIFECYCLE_EVENTS = true;
 

--- a/packages/plugins/rudder_plugin_interface/lib/src/models/rudder_config.dart
+++ b/packages/plugins/rudder_plugin_interface/lib/src/models/rudder_config.dart
@@ -103,6 +103,7 @@ class RudderConfig {
       }
       _mobileConfigMap['autoCollectAdvertId'] =
           mobileConfig.autoCollectAdvertId;
+      _mobileConfigMap['collectDeviceId'] = mobileConfig.collectDeviceId;
       _mobileConfigMap['trackLifecycleEvents'] =
           mobileConfig.trackLifecycleEvents;
       _mobileConfigMap['recordScreenViews'] = mobileConfig.recordScreenViews;
@@ -193,6 +194,9 @@ class MobileConfig {
   /// @param autoCollectAdvertId whether the SDK should automatically collect the advertisingId
   final bool _autoCollectAdvertId;
 
+  /// @param collectDeviceId whether the SDK should send deviceId as part of the event payload
+  final bool _collectDeviceId;
+
   /// @param shouldTrackLifecycleEvents Whether we should track Application lifecycle events automatically
   /// "Application Installed" and "Application Updated" will always be tracked
   final bool _trackLifecycleEvents;
@@ -208,12 +212,14 @@ class MobileConfig {
   MobileConfig(
       {dbCountThreshold = Constants.DB_COUNT_THRESHOLD,
       autoCollectAdvertId = Constants.AUTO_COLLECT_ADVERT_ID,
+      collectDeviceId = Constants.COLLECT_DEVICE_ID,
       trackLifecycleEvents = Constants.TRACK_LIFECYCLE_EVENTS,
       recordScreenViews = Constants.RECORD_SCREEN_VIEWS,
       int sleepTimeOut = Constants.SLEEP_TIMEOUT,
       int configRefreshInterval = Constants.CONFIG_REFRESH_INTERVAL})
       : _dbCountThreshold = dbCountThreshold,
         _autoCollectAdvertId = autoCollectAdvertId,
+        _collectDeviceId = collectDeviceId,
         _trackLifecycleEvents = trackLifecycleEvents,
         _recordScreenViews = recordScreenViews,
         _sleepTimeOut = sleepTimeOut,
@@ -222,6 +228,8 @@ class MobileConfig {
   int get dbCountThreshold => _dbCountThreshold;
 
   bool get autoCollectAdvertId => _autoCollectAdvertId;
+
+  bool get collectDeviceId => _collectDeviceId;
 
   bool get recordScreenViews => _recordScreenViews;
 

--- a/packages/plugins/rudder_plugin_ios/ios/Classes/RudderSdkFlutterPlugin.m
+++ b/packages/plugins/rudder_plugin_ios/ios/Classes/RudderSdkFlutterPlugin.m
@@ -116,7 +116,12 @@ BOOL isRegistrarDetached = NO;
     [[RSClient sharedInstance] alias:[call.arguments objectForKey:@"newId"] options:options];
     return;
   } else if ([call.method isEqualToString:@"reset"]) {
-    [[RSClient sharedInstance] reset];
+    if ([call.arguments objectForKey:@"clearAnonymousId"]) {
+      NSNumber* clearAnonymousId = [call.arguments objectForKey:@"clearAnonymousId"];
+      [[RSClient sharedInstance] reset:[clearAnonymousId boolValue]];
+    } else {
+      [[RSClient sharedInstance] reset];
+    }
     return;
   } else if ([call.method isEqualToString:@"optOut"]) {
     if ([call.arguments objectForKey:@"optOut"]) {

--- a/packages/plugins/rudder_plugin_ios/ios/Classes/RudderSdkFlutterPlugin.m
+++ b/packages/plugins/rudder_plugin_ios/ios/Classes/RudderSdkFlutterPlugin.m
@@ -170,6 +170,7 @@ BOOL isRegistrarDetached = NO;
   [configBuilder withLoglevel:[[configDict objectForKey:@"logLevel"] intValue]];
   [configBuilder
       withConfigRefreshInteval:[[configDict objectForKey:@"configRefreshInterval"] intValue]];
+  [configBuilder withCollectDeviceId:[[configDict objectForKey:@"collectDeviceId"] boolValue]];
   [configBuilder
       withTrackLifecycleEvens:[[configDict objectForKey:@"trackLifecycleEvents"] boolValue]];
   [configBuilder withRecordScreenViews:[[configDict objectForKey:@"recordScreenViews"] boolValue]];

--- a/packages/plugins/rudder_plugin_ios/ios/rudder_plugin_ios.podspec
+++ b/packages/plugins/rudder_plugin_ios/ios/rudder_plugin_ios.podspec
@@ -12,7 +12,7 @@ RudderStack flutter SDK ios plugin project
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency "Rudder", "~> 1.17"
+  s.dependency "Rudder", '>= 1.9.1', '< 2.0.0'
   s.platform = :ios, '8.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/packages/plugins/rudder_plugin_ios/lib/rudder_plugin_ios.dart
+++ b/packages/plugins/rudder_plugin_ios/lib/rudder_plugin_ios.dart
@@ -112,8 +112,10 @@ class RudderSdkFlutterIos extends RudderSdkPlatform {
   }
 
   @override
-  void reset() {
-    _platformChannel.invokeMethod("reset");
+  void reset({bool clearAnonymousId = false}) {
+    Map<String, dynamic> params = {};
+    params["clearAnonymousId"] = clearAnonymousId;
+    _platformChannel.invokeMethod("reset", params);
   }
 
   @override

--- a/packages/plugins/rudder_plugin_ios/pubspec.lock
+++ b/packages/plugins/rudder_plugin_ios/pubspec.lock
@@ -337,7 +337,7 @@ packages:
       path: "../rudder_plugin_interface"
       relative: true
     source: path
-    version: "2.3.1"
+    version: "2.4.0"
   shelf:
     dependency: transitive
     description:

--- a/packages/plugins/rudder_plugin_web/lib/internal/web_js.dart
+++ b/packages/plugins/rudder_plugin_web/lib/internal/web_js.dart
@@ -29,7 +29,7 @@ external alias(
 external group(String groupId, dynamic traits, dynamic options);
 
 @JS("rudderanalytics.reset")
-external reset();
+external reset(bool clearAnonymousId);
 
 @JS("rudderanalytics.getAnonymousId")
 external String? getAnonymousId();

--- a/packages/plugins/rudder_plugin_web/lib/rudder_plugin_web.dart
+++ b/packages/plugins/rudder_plugin_web/lib/rudder_plugin_web.dart
@@ -104,8 +104,8 @@ class RudderSdkFlutterWeb extends RudderSdkPlatform {
   }
 
   @override
-  void reset() {
-    web_js.reset();
+  void reset({bool clearAnonymousId = false}) {
+    web_js.reset(clearAnonymousId);
   }
 
   @override

--- a/packages/plugins/rudder_plugin_web/pubspec.lock
+++ b/packages/plugins/rudder_plugin_web/pubspec.lock
@@ -342,7 +342,7 @@ packages:
       path: "../rudder_plugin_interface"
       relative: true
     source: path
-    version: "2.3.1"
+    version: "2.4.0"
   shelf:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -473,84 +473,84 @@ packages:
       path: "packages/integrations/rudder_integration_adjust_flutter"
       relative: true
     source: path
-    version: "1.0.5"
+    version: "1.0.7"
   rudder_integration_amplitude_flutter:
     dependency: "direct main"
     description:
       path: "packages/integrations/rudder_integration_amplitude_flutter"
       relative: true
     source: path
-    version: "1.0.5"
+    version: "1.0.7"
   rudder_integration_appcenter_flutter:
     dependency: "direct main"
     description:
       path: "packages/integrations/rudder_integration_appcenter_flutter"
       relative: true
     source: path
-    version: "1.1.5"
+    version: "1.1.7"
   rudder_integration_appsflyer_flutter:
     dependency: "direct main"
     description:
       path: "packages/integrations/rudder_integration_appsflyer_flutter"
       relative: true
     source: path
-    version: "1.1.2"
+    version: "1.1.4"
   rudder_integration_braze_flutter:
     dependency: "direct main"
     description:
       path: "packages/integrations/rudder_integration_braze_flutter"
       relative: true
     source: path
-    version: "1.0.5"
+    version: "1.0.7"
   rudder_integration_firebase_flutter:
     dependency: "direct main"
     description:
       path: "packages/integrations/rudder_integration_firebase_flutter"
       relative: true
     source: path
-    version: "2.0.4"
+    version: "2.0.6"
   rudder_integration_leanplum_flutter:
     dependency: "direct main"
     description:
       path: "packages/integrations/rudder_integration_leanplum_flutter"
       relative: true
     source: path
-    version: "1.0.5"
+    version: "1.0.7"
   rudder_plugin_android:
     dependency: "direct overridden"
     description:
       path: "packages/plugins/rudder_plugin_android"
       relative: true
     source: path
-    version: "2.2.2"
+    version: "2.3.0"
   rudder_plugin_ios:
     dependency: "direct overridden"
     description:
       path: "packages/plugins/rudder_plugin_ios"
       relative: true
     source: path
-    version: "2.2.2"
+    version: "2.3.0"
   rudder_plugin_web:
     dependency: "direct overridden"
     description:
       path: "packages/plugins/rudder_plugin_web"
       relative: true
     source: path
-    version: "2.2.3"
+    version: "2.3.1"
   rudder_sdk_flutter:
     dependency: "direct main"
     description:
       path: "packages/plugins/rudder_plugin"
       relative: true
     source: path
-    version: "2.3.3"
+    version: "2.4.1"
   rudder_sdk_flutter_platform_interface:
     dependency: "direct overridden"
     description:
       path: "packages/plugins/rudder_plugin_interface"
       relative: true
     source: path
-    version: "2.3.1"
+    version: "2.4.0"
   shelf:
     dependency: transitive
     description:


### PR DESCRIPTION
  **Made device id collection by the SDK configurable and also stopped using deviceId as anonymous Id**
  

-   Added a new property `collectDeviceId` in the `MobileConfig` class and when this property is set to false,  SDK will not use the value of Device Id in any possible manner and you will observe the following changes:
    1.  `context.device.id` will not be sent as part of the event payload 
    2.  If the value of `anonymousId` currently used by the SDK is equal to `DEVICE_ID/IDFV`, it will changed to a UUID and this would be reflected at `context.traits.anonymousId` and `.anonymousId`
   
- **Info**: Till now, SDK would use `DEVICE_ID/IDFV` as `anonymousId` by default, if the user is not overriding the default value by using the `putAnonymousId` API.   
- For the Customers who are not overriding the default value of `anonymousId`, which means when the value of `anonymousId` is equal to `DEVICE_ID/IDFV`, upgrading to `2.5.0` and setting property `collectDeviceId` to `false` would change the `anonymousId` of all of your existing users to a new UUID. 
- Both the above changes are introduced to make the SDK more compliant with all the compliance policies around the collection of Device Id
- Added a new `reset` API which would accept a boolean, if this API is called with `true` the anonymousId would also be refreshed/reset with a new UUID.


## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [x] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
