### PR TITLE
fix: remove db encryption feature for ios platform in flutter sdk

### DIFF
--- a/packages/example/ios/Podfile.lock
+++ b/packages/example/ios/Podfile.lock
@@ -100,6 +100,7 @@ PODS:
     - GoogleUtilities/Logger
   - GoogleUtilities/UserDefaults (7.11.5):
     - GoogleUtilities/Logger
+  - Leanplum-iOS-SDK (4.0.0)
   - MetricsReporter (1.1.0):
     - RSCrashReporter (~> 1.0.0)
     - RudderKit (~> 1.4.0)
@@ -130,6 +131,9 @@ PODS:
   - Rudder-Firebase (3.0.0):
     - FirebaseAnalytics (= 10.3.0)
     - Rudder (~> 1.8)
+  - Rudder-Leanplum (1.0.2):
+    - Leanplum-iOS-SDK (= 4.0.0)
+    - Rudder (~> 1.0)
   - rudder_integration_adjust_flutter (1.0.1):
     - Flutter
     - Rudder-Adjust (= 1.0.0)
@@ -154,6 +158,10 @@ PODS:
     - Flutter
     - Rudder-Firebase (= 3.0.0)
     - rudder_plugin_ios
+  - rudder_integration_leanplum_flutter (1.0.1):
+    - Flutter
+    - Rudder-Leanplum (= 1.0.2)
+    - rudder_plugin_ios
   - rudder_plugin_ios (0.0.1):
     - Flutter
     - Rudder (< 2.0.0, >= 1.20.0)
@@ -170,6 +178,7 @@ DEPENDENCIES:
   - rudder_integration_appsflyer_flutter (from `.symlinks/plugins/rudder_integration_appsflyer_flutter/ios`)
   - rudder_integration_braze_flutter (from `.symlinks/plugins/rudder_integration_braze_flutter/ios`)
   - rudder_integration_firebase_flutter (from `.symlinks/plugins/rudder_integration_firebase_flutter/ios`)
+  - rudder_integration_leanplum_flutter (from `.symlinks/plugins/rudder_integration_leanplum_flutter/ios`)
   - rudder_plugin_ios (from `.symlinks/plugins/rudder_plugin_ios/ios`)
 
 SPEC REPOS:
@@ -185,6 +194,7 @@ SPEC REPOS:
     - FirebaseInstallations
     - GoogleAppMeasurement
     - GoogleUtilities
+    - Leanplum-iOS-SDK
     - MetricsReporter
     - nanopb
     - PromisesObjC
@@ -196,6 +206,7 @@ SPEC REPOS:
     - Rudder-Appsflyer
     - Rudder-Braze
     - Rudder-Firebase
+    - Rudder-Leanplum
     - RudderKit
     - SDWebImage
 
@@ -214,6 +225,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/rudder_integration_braze_flutter/ios"
   rudder_integration_firebase_flutter:
     :path: ".symlinks/plugins/rudder_integration_firebase_flutter/ios"
+  rudder_integration_leanplum_flutter:
+    :path: ".symlinks/plugins/rudder_integration_leanplum_flutter/ios"
   rudder_plugin_ios:
     :path: ".symlinks/plugins/rudder_plugin_ios/ios"
 
@@ -230,6 +243,7 @@ SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   GoogleAppMeasurement: c7d6fff39bf2d829587d74088d582e32d75133c3
   GoogleUtilities: 13e2c67ede716b8741c7989e26893d151b2b2084
+  Leanplum-iOS-SDK: 8115f65d185eb94d94c4ab08176dfcb4a8b97926
   MetricsReporter: 319426a9cca7539066fff0ad4106572c644661ed
   nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
   PromisesObjC: c50d2056b5253dadbd6c2bea79b0674bd5a52fa4
@@ -241,12 +255,14 @@ SPEC CHECKSUMS:
   Rudder-Appsflyer: b19834ae8d933444411813556e0fe70a33df224a
   Rudder-Braze: e58e0e8163a2dcf0d45ec2d12bdb0ec3329c3681
   Rudder-Firebase: 9f061bf3c23900e1a8f32f8b079ae17e04874f17
+  Rudder-Leanplum: e2c9ffa48ea227c3574998afa1e287061ad042ee
   rudder_integration_adjust_flutter: 7b9b8794548490bd032937966ebde20172b2809b
   rudder_integration_amplitude_flutter: 0c85fc19b9f3b4f33df87b60fa80dac0c01dbd36
   rudder_integration_appcenter_flutter: b9c8d7faec570e3a22b7fc7236e4da21a243d4f9
   rudder_integration_appsflyer_flutter: 4736dc267dd6e8b3e7321e4999ed1bb751b9ad59
   rudder_integration_braze_flutter: ddc8cb4214059122d2f7f6f2aff5772d3fb2e5fd
   rudder_integration_firebase_flutter: 2406b968e85e4a3175b64ccc8f8de98eca3b3d2e
+  rudder_integration_leanplum_flutter: c6e83564dc7c1a96cec8b97c6e75f9b3c1958c91
   rudder_plugin_ios: 04662d54ab52c6265b5effb50ad5eb748ea0322d
   RudderKit: f272f9872183946452ac94cd7bb2244a71e6ca8f
   SDWebImage: ebdbcebc7933a45226d9313bd0118bc052ad458b

--- a/packages/example/ios/Podfile.lock
+++ b/packages/example/ios/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - Adjust (4.34.1):
-    - Adjust/Core (= 4.34.1)
-  - Adjust/Core (4.34.1)
+  - Adjust (4.35.0):
+    - Adjust/Core (= 4.35.0)
+  - Adjust/Core (4.35.0)
   - Amplitude (7.2.2)
   - Appboy-iOS-SDK (4.4.2):
     - Appboy-iOS-SDK/UI (= 4.4.2)
@@ -20,13 +20,13 @@ PODS:
     - Appboy-iOS-SDK/Core
     - Appboy-iOS-SDK/InAppMessage
     - Appboy-iOS-SDK/NewsFeed
-  - AppCenter (5.0.3):
-    - AppCenter/Analytics (= 5.0.3)
-    - AppCenter/Crashes (= 5.0.3)
-  - AppCenter/Analytics (5.0.3):
+  - AppCenter (5.0.4):
+    - AppCenter/Analytics (= 5.0.4)
+    - AppCenter/Crashes (= 5.0.4)
+  - AppCenter/Analytics (5.0.4):
     - AppCenter/Core
-  - AppCenter/Core (5.0.3)
-  - AppCenter/Crashes (5.0.3):
+  - AppCenter/Core (5.0.4)
+  - AppCenter/Crashes (5.0.4):
     - AppCenter/Core
   - AppsFlyerFramework (6.9.2):
     - AppsFlyerFramework/Main (= 6.9.2)
@@ -49,13 +49,13 @@ PODS:
     - GoogleUtilities/Network (~> 7.8)
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseCore (10.14.0):
+  - FirebaseCore (10.15.0):
     - FirebaseCoreInternal (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/Logger (~> 7.8)
-  - FirebaseCoreInternal (10.14.0):
+  - FirebaseCoreInternal (10.15.0):
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
-  - FirebaseInstallations (10.14.0):
+  - FirebaseInstallations (10.15.0):
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
@@ -100,8 +100,8 @@ PODS:
     - GoogleUtilities/Logger
   - GoogleUtilities/UserDefaults (7.11.5):
     - GoogleUtilities/Logger
-  - Leanplum-iOS-SDK (4.0.0)
-  - MetricsReporter (1.0.0):
+  - MetricsReporter (1.1.0):
+    - RSCrashReporter (~> 1.0.0)
     - RudderKit (~> 1.4.0)
   - nanopb (2.30909.0):
     - nanopb/decode (= 2.30909.0)
@@ -109,8 +109,9 @@ PODS:
   - nanopb/decode (2.30909.0)
   - nanopb/encode (2.30909.0)
   - PromisesObjC (2.3.1)
-  - Rudder (1.19.2):
-    - MetricsReporter (= 1.0.0)
+  - RSCrashReporter (1.0.0)
+  - Rudder (1.20.0):
+    - MetricsReporter (= 1.1.0)
   - Rudder-Adjust (1.0.0):
     - Adjust
     - Rudder
@@ -155,11 +156,11 @@ PODS:
     - rudder_plugin_ios
   - rudder_plugin_ios (0.0.1):
     - Flutter
-    - Rudder (< 2.0.0, >= 1.19.2)
+    - Rudder (< 2.0.0, >= 1.20.0)
   - RudderKit (1.4.0)
-  - SDWebImage (5.17.0):
-    - SDWebImage/Core (= 5.17.0)
-  - SDWebImage/Core (5.17.0)
+  - SDWebImage (5.18.1):
+    - SDWebImage/Core (= 5.18.1)
+  - SDWebImage/Core (5.18.1)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
@@ -184,10 +185,10 @@ SPEC REPOS:
     - FirebaseInstallations
     - GoogleAppMeasurement
     - GoogleUtilities
-    - Leanplum-iOS-SDK
     - MetricsReporter
     - nanopb
     - PromisesObjC
+    - RSCrashReporter
     - Rudder
     - Rudder-Adjust
     - Rudder-Amplitude
@@ -195,7 +196,6 @@ SPEC REPOS:
     - Rudder-Appsflyer
     - Rudder-Braze
     - Rudder-Firebase
-    - Rudder-Leanplum
     - RudderKit
     - SDWebImage
 
@@ -218,23 +218,23 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/rudder_plugin_ios/ios"
 
 SPEC CHECKSUMS:
-  Adjust: 1410b6ccbce29c91b8e88064186a7b103244fa43
+  Adjust: 17a9c4f481065eb717aacdf4a0ab84a55c8fdf39
   Amplitude: 517cdc7c485bda64b685174426ecbf17746eb16a
   Appboy-iOS-SDK: 4a7dfe908639da81e5e85849355f6066b58b4cc6
-  AppCenter: a4070ec3d4418b5539067a51f57155012e486ebd
+  AppCenter: 85c92db0759d2792a65eb61d6842d2e86611a49a
   AppsFlyerFramework: 75e2e46970e520c88b0456dc6fae98c51b36163a
   FirebaseAnalytics: 036232b6a1e2918e5f67572417be1173576245f3
-  FirebaseCore: 6fc17ac9f03509d51c131298aacb3ee5698b4f02
-  FirebaseCoreInternal: d558159ee6cc4b823c2296ecc193de9f6d9a5bb3
-  FirebaseInstallations: f672b1eda64e6381c21d424a2f680a943fd83f3b
+  FirebaseCore: 2cec518b43635f96afe7ac3a9c513e47558abd2e
+  FirebaseCoreInternal: 2f4bee5ed00301b5e56da0849268797a2dd31fb4
+  FirebaseInstallations: cae95cab0f965ce05b805189de1d4c70b11c76fb
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   GoogleAppMeasurement: c7d6fff39bf2d829587d74088d582e32d75133c3
   GoogleUtilities: 13e2c67ede716b8741c7989e26893d151b2b2084
-  Leanplum-iOS-SDK: 8115f65d185eb94d94c4ab08176dfcb4a8b97926
-  MetricsReporter: 35d1a8e62cd99e1434bc8fdd06bf2baf7cb23e42
+  MetricsReporter: 319426a9cca7539066fff0ad4106572c644661ed
   nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
   PromisesObjC: c50d2056b5253dadbd6c2bea79b0674bd5a52fa4
-  Rudder: 26a9b6756628cb953f3151d835104ac9f5635861
+  RSCrashReporter: e9ccaebd996263f8325a6cbef44ff74aa5f58e30
+  Rudder: 6d1dc8dd6901d503666002ecc9973c2c11d29a89
   Rudder-Adjust: 5f14011c8f7237d80a96a10655ac03ebf832bcc4
   Rudder-Amplitude: f845cc125a1a58d4de6155391a2b0392815ae898
   Rudder-AppCenter: 9eca9241e3707a0e9610714dd91dc8da4bae7e1f
@@ -247,10 +247,9 @@ SPEC CHECKSUMS:
   rudder_integration_appsflyer_flutter: 4736dc267dd6e8b3e7321e4999ed1bb751b9ad59
   rudder_integration_braze_flutter: ddc8cb4214059122d2f7f6f2aff5772d3fb2e5fd
   rudder_integration_firebase_flutter: 2406b968e85e4a3175b64ccc8f8de98eca3b3d2e
-  rudder_integration_leanplum_flutter: c6e83564dc7c1a96cec8b97c6e75f9b3c1958c91
-  rudder_plugin_ios: 6d73f06a3c4f2f5906746790af65e697976b04bd
+  rudder_plugin_ios: 04662d54ab52c6265b5effb50ad5eb748ea0322d
   RudderKit: f272f9872183946452ac94cd7bb2244a71e6ca8f
-  SDWebImage: 750adf017a315a280c60fde706ab1e552a3ae4e9
+  SDWebImage: ebdbcebc7933a45226d9313bd0118bc052ad458b
 
 PODFILE CHECKSUM: 5265e733c786a5987c9aa8f08d969fb3ef180aca
 

--- a/packages/example/pubspec.lock
+++ b/packages/example/pubspec.lock
@@ -370,6 +370,13 @@ packages:
       relative: true
     source: path
     version: "2.1.0"
+  rudder_integration_leanplum_flutter:
+    dependency: "direct main"
+    description:
+      path: "../integrations/rudder_integration_leanplum_flutter"
+      relative: true
+    source: path
+    version: "1.1.0"
   rudder_plugin_android:
     dependency: "direct overridden"
     description:

--- a/packages/example/pubspec.lock
+++ b/packages/example/pubspec.lock
@@ -334,84 +334,77 @@ packages:
       path: "../integrations/rudder_integration_adjust_flutter"
       relative: true
     source: path
-    version: "1.0.7"
+    version: "1.1.0"
   rudder_integration_amplitude_flutter:
     dependency: "direct main"
     description:
       path: "../integrations/rudder_integration_amplitude_flutter"
       relative: true
     source: path
-    version: "1.0.7"
+    version: "1.1.0"
   rudder_integration_appcenter_flutter:
     dependency: "direct main"
     description:
       path: "../integrations/rudder_integration_appcenter_flutter"
       relative: true
     source: path
-    version: "1.1.7"
+    version: "1.2.0"
   rudder_integration_appsflyer_flutter:
     dependency: "direct main"
     description:
       path: "../integrations/rudder_integration_appsflyer_flutter"
       relative: true
     source: path
-    version: "1.1.4"
+    version: "1.1.5"
   rudder_integration_braze_flutter:
     dependency: "direct main"
     description:
       path: "../integrations/rudder_integration_braze_flutter"
       relative: true
     source: path
-    version: "1.0.7"
+    version: "1.1.0"
   rudder_integration_firebase_flutter:
     dependency: "direct main"
     description:
       path: "../integrations/rudder_integration_firebase_flutter"
       relative: true
     source: path
-    version: "2.0.6"
-  rudder_integration_leanplum_flutter:
-    dependency: "direct main"
-    description:
-      path: "../integrations/rudder_integration_leanplum_flutter"
-      relative: true
-    source: path
-    version: "1.0.7"
+    version: "2.1.0"
   rudder_plugin_android:
     dependency: "direct overridden"
     description:
       path: "../plugins/rudder_plugin_android"
       relative: true
     source: path
-    version: "2.3.0"
+    version: "2.4.0"
   rudder_plugin_ios:
     dependency: "direct overridden"
     description:
       path: "../plugins/rudder_plugin_ios"
       relative: true
     source: path
-    version: "2.3.0"
+    version: "2.4.0"
   rudder_plugin_web:
     dependency: "direct overridden"
     description:
       path: "../plugins/rudder_plugin_web"
       relative: true
     source: path
-    version: "2.3.1"
+    version: "2.4.0"
   rudder_sdk_flutter:
     dependency: "direct main"
     description:
       path: "../plugins/rudder_plugin"
       relative: true
     source: path
-    version: "2.4.1"
+    version: "2.5.0"
   rudder_sdk_flutter_platform_interface:
     dependency: "direct overridden"
     description:
       path: "../plugins/rudder_plugin_interface"
       relative: true
     source: path
-    version: "2.4.0"
+    version: "2.5.0"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/packages/example/pubspec.yaml
+++ b/packages/example/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   rudder_integration_braze_flutter: ^1.1.0
   rudder_integration_appcenter_flutter: ^1.2.0
   rudder_integration_adjust_flutter: ^1.1.0
-  # rudder_integration_leanplum_flutter: ^1.0.7
+  rudder_integration_leanplum_flutter: ^1.0.7
   rudder_integration_appsflyer_flutter: ^1.1.5
     # When depending on this package from a real application you should use:
     #   rudder_sdk_flutter: ^x.y.z

--- a/packages/integrations/rudder_integration_adjust_flutter/pubspec.lock
+++ b/packages/integrations/rudder_integration_adjust_flutter/pubspec.lock
@@ -342,35 +342,35 @@ packages:
       path: "../../plugins/rudder_plugin_android"
       relative: true
     source: path
-    version: "2.3.0"
+    version: "2.4.0"
   rudder_plugin_ios:
     dependency: "direct overridden"
     description:
       path: "../../plugins/rudder_plugin_ios"
       relative: true
     source: path
-    version: "2.3.0"
+    version: "2.4.0"
   rudder_plugin_web:
     dependency: "direct overridden"
     description:
       path: "../../plugins/rudder_plugin_web"
       relative: true
     source: path
-    version: "2.3.1"
+    version: "2.4.0"
   rudder_sdk_flutter:
     dependency: "direct main"
     description:
       path: "../../plugins/rudder_plugin"
       relative: true
     source: path
-    version: "2.4.1"
+    version: "2.5.0"
   rudder_sdk_flutter_platform_interface:
     dependency: "direct main"
     description:
       path: "../../plugins/rudder_plugin_interface"
       relative: true
     source: path
-    version: "2.4.0"
+    version: "2.5.0"
   shelf:
     dependency: transitive
     description:

--- a/packages/integrations/rudder_integration_amplitude_flutter/pubspec.lock
+++ b/packages/integrations/rudder_integration_amplitude_flutter/pubspec.lock
@@ -342,35 +342,35 @@ packages:
       path: "../../plugins/rudder_plugin_android"
       relative: true
     source: path
-    version: "2.3.0"
+    version: "2.4.0"
   rudder_plugin_ios:
     dependency: "direct overridden"
     description:
       path: "../../plugins/rudder_plugin_ios"
       relative: true
     source: path
-    version: "2.3.0"
+    version: "2.4.0"
   rudder_plugin_web:
     dependency: "direct overridden"
     description:
       path: "../../plugins/rudder_plugin_web"
       relative: true
     source: path
-    version: "2.3.1"
+    version: "2.4.0"
   rudder_sdk_flutter:
     dependency: "direct main"
     description:
       path: "../../plugins/rudder_plugin"
       relative: true
     source: path
-    version: "2.4.1"
+    version: "2.5.0"
   rudder_sdk_flutter_platform_interface:
     dependency: "direct main"
     description:
       path: "../../plugins/rudder_plugin_interface"
       relative: true
     source: path
-    version: "2.4.0"
+    version: "2.5.0"
   shelf:
     dependency: transitive
     description:

--- a/packages/integrations/rudder_integration_appcenter_flutter/pubspec.lock
+++ b/packages/integrations/rudder_integration_appcenter_flutter/pubspec.lock
@@ -342,35 +342,35 @@ packages:
       path: "../../plugins/rudder_plugin_android"
       relative: true
     source: path
-    version: "2.3.0"
+    version: "2.4.0"
   rudder_plugin_ios:
     dependency: "direct overridden"
     description:
       path: "../../plugins/rudder_plugin_ios"
       relative: true
     source: path
-    version: "2.3.0"
+    version: "2.4.0"
   rudder_plugin_web:
     dependency: "direct overridden"
     description:
       path: "../../plugins/rudder_plugin_web"
       relative: true
     source: path
-    version: "2.3.1"
+    version: "2.4.0"
   rudder_sdk_flutter:
     dependency: "direct main"
     description:
       path: "../../plugins/rudder_plugin"
       relative: true
     source: path
-    version: "2.4.1"
+    version: "2.5.0"
   rudder_sdk_flutter_platform_interface:
     dependency: "direct main"
     description:
       path: "../../plugins/rudder_plugin_interface"
       relative: true
     source: path
-    version: "2.4.0"
+    version: "2.5.0"
   shelf:
     dependency: transitive
     description:

--- a/packages/integrations/rudder_integration_braze_flutter/pubspec.lock
+++ b/packages/integrations/rudder_integration_braze_flutter/pubspec.lock
@@ -342,35 +342,35 @@ packages:
       path: "../../plugins/rudder_plugin_android"
       relative: true
     source: path
-    version: "2.3.0"
+    version: "2.4.0"
   rudder_plugin_ios:
     dependency: "direct overridden"
     description:
       path: "../../plugins/rudder_plugin_ios"
       relative: true
     source: path
-    version: "2.3.0"
+    version: "2.4.0"
   rudder_plugin_web:
     dependency: "direct overridden"
     description:
       path: "../../plugins/rudder_plugin_web"
       relative: true
     source: path
-    version: "2.3.1"
+    version: "2.4.0"
   rudder_sdk_flutter:
     dependency: "direct main"
     description:
       path: "../../plugins/rudder_plugin"
       relative: true
     source: path
-    version: "2.4.1"
+    version: "2.5.0"
   rudder_sdk_flutter_platform_interface:
     dependency: "direct main"
     description:
       path: "../../plugins/rudder_plugin_interface"
       relative: true
     source: path
-    version: "2.4.0"
+    version: "2.5.0"
   shelf:
     dependency: transitive
     description:

--- a/packages/integrations/rudder_integration_firebase_flutter/pubspec.lock
+++ b/packages/integrations/rudder_integration_firebase_flutter/pubspec.lock
@@ -342,35 +342,35 @@ packages:
       path: "../../plugins/rudder_plugin_android"
       relative: true
     source: path
-    version: "2.3.0"
+    version: "2.4.0"
   rudder_plugin_ios:
     dependency: "direct overridden"
     description:
       path: "../../plugins/rudder_plugin_ios"
       relative: true
     source: path
-    version: "2.3.0"
+    version: "2.4.0"
   rudder_plugin_web:
     dependency: "direct overridden"
     description:
       path: "../../plugins/rudder_plugin_web"
       relative: true
     source: path
-    version: "2.3.1"
+    version: "2.4.0"
   rudder_sdk_flutter:
     dependency: "direct main"
     description:
       path: "../../plugins/rudder_plugin"
       relative: true
     source: path
-    version: "2.4.1"
+    version: "2.5.0"
   rudder_sdk_flutter_platform_interface:
     dependency: "direct main"
     description:
       path: "../../plugins/rudder_plugin_interface"
       relative: true
     source: path
-    version: "2.4.0"
+    version: "2.5.0"
   shelf:
     dependency: transitive
     description:

--- a/packages/integrations/rudder_integration_leanplum_flutter/pubspec.lock
+++ b/packages/integrations/rudder_integration_leanplum_flutter/pubspec.lock
@@ -342,35 +342,35 @@ packages:
       path: "../../plugins/rudder_plugin_android"
       relative: true
     source: path
-    version: "2.3.0"
+    version: "2.4.0"
   rudder_plugin_ios:
     dependency: "direct overridden"
     description:
       path: "../../plugins/rudder_plugin_ios"
       relative: true
     source: path
-    version: "2.3.0"
+    version: "2.4.0"
   rudder_plugin_web:
     dependency: "direct overridden"
     description:
       path: "../../plugins/rudder_plugin_web"
       relative: true
     source: path
-    version: "2.3.1"
+    version: "2.4.0"
   rudder_sdk_flutter:
     dependency: "direct main"
     description:
       path: "../../plugins/rudder_plugin"
       relative: true
     source: path
-    version: "2.4.1"
+    version: "2.5.0"
   rudder_sdk_flutter_platform_interface:
     dependency: "direct main"
     description:
       path: "../../plugins/rudder_plugin_interface"
       relative: true
     source: path
-    version: "2.4.0"
+    version: "2.5.0"
   shelf:
     dependency: transitive
     description:

--- a/packages/plugins/rudder_plugin/pubspec.lock
+++ b/packages/plugins/rudder_plugin/pubspec.lock
@@ -342,28 +342,28 @@ packages:
       path: "../rudder_plugin_android"
       relative: true
     source: path
-    version: "2.3.0"
+    version: "2.4.0"
   rudder_plugin_ios:
     dependency: "direct main"
     description:
       path: "../rudder_plugin_ios"
       relative: true
     source: path
-    version: "2.3.0"
+    version: "2.4.0"
   rudder_plugin_web:
     dependency: "direct main"
     description:
       path: "../rudder_plugin_web"
       relative: true
     source: path
-    version: "2.3.1"
+    version: "2.4.0"
   rudder_sdk_flutter_platform_interface:
     dependency: "direct main"
     description:
       path: "../rudder_plugin_interface"
       relative: true
     source: path
-    version: "2.4.0"
+    version: "2.5.0"
   shelf:
     dependency: transitive
     description:

--- a/packages/plugins/rudder_plugin_android/pubspec.lock
+++ b/packages/plugins/rudder_plugin_android/pubspec.lock
@@ -337,7 +337,7 @@ packages:
       path: "../rudder_plugin_interface"
       relative: true
     source: path
-    version: "2.4.0"
+    version: "2.5.0"
   shelf:
     dependency: transitive
     description:

--- a/packages/plugins/rudder_plugin_ios/ios/Classes/RudderSdkFlutterPlugin.m
+++ b/packages/plugins/rudder_plugin_ios/ios/Classes/RudderSdkFlutterPlugin.m
@@ -185,15 +185,16 @@ BOOL isRegistrarDetached = NO;
       [configBuilder withDataResidencyServer:EU];
   }
 
-  if([configDict objectForKey:@"dbEncryption"]) {
-    NSDictionary* dbEncryptionDict = [configDict objectForKey:@"dbEncryption"];
-    BOOL enabled = [[dbEncryptionDict objectForKey:@"enabled"] boolValue];
-    NSString* encryptionKey = [dbEncryptionDict objectForKey:@"key"];
+  // to be implemented in future
+  // if([configDict objectForKey:@"dbEncryption"]) {
+  //   NSDictionary* dbEncryptionDict = [configDict objectForKey:@"dbEncryption"];
+  //   BOOL enabled = [[dbEncryptionDict objectForKey:@"enabled"] boolValue];
+  //   NSString* encryptionKey = [dbEncryptionDict objectForKey:@"key"];
 
-    if (encryptionKey != nil && [encryptionKey length] != 0) {
-        [configBuilder withDBEncryption:[[RSDBEncryption alloc] initWithKey:encryptionKey enable:enabled]];
-    }
-  }
+  //   if (encryptionKey != nil && [encryptionKey length] != 0) {
+  //       [configBuilder withDBEncryption:[[RSDBEncryption alloc] initWithKey:encryptionKey enable:enabled]];
+  //   }
+  // }
 
   if (integrationList != nil) {
     for (id<RSIntegrationFactory> integration in integrationList) {

--- a/packages/plugins/rudder_plugin_ios/ios/Classes/RudderSdkFlutterPlugin.m
+++ b/packages/plugins/rudder_plugin_ios/ios/Classes/RudderSdkFlutterPlugin.m
@@ -185,7 +185,7 @@ BOOL isRegistrarDetached = NO;
       [configBuilder withDataResidencyServer:EU];
   }
 
-  // to be implemented in future
+  // todo: to be implemented in future
   // if([configDict objectForKey:@"dbEncryption"]) {
   //   NSDictionary* dbEncryptionDict = [configDict objectForKey:@"dbEncryption"];
   //   BOOL enabled = [[dbEncryptionDict objectForKey:@"enabled"] boolValue];

--- a/packages/plugins/rudder_plugin_ios/ios/rudder_plugin_ios.podspec
+++ b/packages/plugins/rudder_plugin_ios/ios/rudder_plugin_ios.podspec
@@ -12,7 +12,7 @@ RudderStack flutter SDK ios plugin project
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency "Rudder", '>= 1.19.2', '< 2.0.0'
+  s.dependency "Rudder", '>= 1.20.0', '< 2.0.0'
   s.platform = :ios, '8.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/packages/plugins/rudder_plugin_ios/pubspec.lock
+++ b/packages/plugins/rudder_plugin_ios/pubspec.lock
@@ -337,7 +337,7 @@ packages:
       path: "../rudder_plugin_interface"
       relative: true
     source: path
-    version: "2.4.0"
+    version: "2.5.0"
   shelf:
     dependency: transitive
     description:

--- a/packages/plugins/rudder_plugin_web/pubspec.lock
+++ b/packages/plugins/rudder_plugin_web/pubspec.lock
@@ -342,7 +342,7 @@ packages:
       path: "../rudder_plugin_interface"
       relative: true
     source: path
-    version: "2.4.0"
+    version: "2.5.0"
   shelf:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -473,84 +473,84 @@ packages:
       path: "packages/integrations/rudder_integration_adjust_flutter"
       relative: true
     source: path
-    version: "1.0.7"
+    version: "1.1.0"
   rudder_integration_amplitude_flutter:
     dependency: "direct main"
     description:
       path: "packages/integrations/rudder_integration_amplitude_flutter"
       relative: true
     source: path
-    version: "1.0.7"
+    version: "1.1.0"
   rudder_integration_appcenter_flutter:
     dependency: "direct main"
     description:
       path: "packages/integrations/rudder_integration_appcenter_flutter"
       relative: true
     source: path
-    version: "1.1.7"
+    version: "1.2.0"
   rudder_integration_appsflyer_flutter:
     dependency: "direct main"
     description:
       path: "packages/integrations/rudder_integration_appsflyer_flutter"
       relative: true
     source: path
-    version: "1.1.4"
+    version: "1.1.5"
   rudder_integration_braze_flutter:
     dependency: "direct main"
     description:
       path: "packages/integrations/rudder_integration_braze_flutter"
       relative: true
     source: path
-    version: "1.0.7"
+    version: "1.1.0"
   rudder_integration_firebase_flutter:
     dependency: "direct main"
     description:
       path: "packages/integrations/rudder_integration_firebase_flutter"
       relative: true
     source: path
-    version: "2.0.6"
+    version: "2.1.0"
   rudder_integration_leanplum_flutter:
     dependency: "direct main"
     description:
       path: "packages/integrations/rudder_integration_leanplum_flutter"
       relative: true
     source: path
-    version: "1.0.7"
+    version: "1.1.0"
   rudder_plugin_android:
     dependency: "direct overridden"
     description:
       path: "packages/plugins/rudder_plugin_android"
       relative: true
     source: path
-    version: "2.3.0"
+    version: "2.4.0"
   rudder_plugin_ios:
     dependency: "direct overridden"
     description:
       path: "packages/plugins/rudder_plugin_ios"
       relative: true
     source: path
-    version: "2.3.0"
+    version: "2.4.0"
   rudder_plugin_web:
     dependency: "direct overridden"
     description:
       path: "packages/plugins/rudder_plugin_web"
       relative: true
     source: path
-    version: "2.3.1"
+    version: "2.4.0"
   rudder_sdk_flutter:
     dependency: "direct main"
     description:
       path: "packages/plugins/rudder_plugin"
       relative: true
     source: path
-    version: "2.4.1"
+    version: "2.5.0"
   rudder_sdk_flutter_platform_interface:
     dependency: "direct overridden"
     description:
       path: "packages/plugins/rudder_plugin_interface"
       relative: true
     source: path
-    version: "2.4.0"
+    version: "2.5.0"
   shelf:
     dependency: transitive
     description:


### PR DESCRIPTION
## Description of the change

* Removed DB Encryption feature for the iOS platform
* Upgraded the iOS SDK to be at least 1.20.0 to fix the invalid JSON requests being sent to the Data plane.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#124 ](https://github.com/rudderlabs/rudder-sdk-flutter/issues/124) 

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
