### PR TITLE
fix: enable static framework setting in Kochava iOS Integration Podspec

### DIFF
--- a/packages/example/ios/Podfile
+++ b/packages/example/ios/Podfile
@@ -28,7 +28,7 @@ require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelpe
 flutter_ios_podfile_setup
 
 target 'Runner' do
-  use_frameworks! :linkage=> :static
+  use_frameworks!
   use_modular_headers!
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))

--- a/packages/example/ios/Podfile.lock
+++ b/packages/example/ios/Podfile.lock
@@ -191,7 +191,7 @@ PODS:
     - RudderDatabaseEncryption (~> 1.0.0)
   - rudder_plugin_ios (0.0.1):
     - Flutter
-    - Rudder (< 2.0.0, >= 1.24.1)
+    - Rudder (< 2.0.0, >= 1.26.3)
   - RudderDatabaseEncryption (1.0.0):
     - Rudder (~> 1.20)
     - SQLCipher (~> 4.0)
@@ -313,15 +313,15 @@ SPEC CHECKSUMS:
   rudder_integration_appsflyer_flutter: 47ac2556ff3b538c9ca5a144ca1c616a6ee6415b
   rudder_integration_braze_flutter: 7c05ce87d5bfc0f6dc00e641f09595e8867a1ebe
   rudder_integration_firebase_flutter: e68a0a215725a04883a83c7f0d16b68f3d6c217d
-  rudder_integration_kochava_flutter: e9b972b2a09ebf7038245a18e00f206b0d2ec719
+  rudder_integration_kochava_flutter: 8403b6f8f797c742e43d38dd24a803f1e7186a81
   rudder_integration_leanplum_flutter: e78fd45ea2b251891a8c1ced32071b3254077862
   rudder_plugin_db_encryption: dd7c5dccfe409c14a226dbc4be19256929060f9a
-  rudder_plugin_ios: 2cd7dfdd8c8c3a663d1a6ed3ee8c768cd452b461
+  rudder_plugin_ios: a337ccdc5313621e0b1260551e8ebbc6bb492c36
   RudderDatabaseEncryption: 409b8623c114a43af6332a694601373fde45e1ca
   RudderKit: f272f9872183946452ac94cd7bb2244a71e6ca8f
   SDWebImage: 40b0b4053e36c660a764958bff99eed16610acbb
   SQLCipher: 838309284f29953a28ad2e81d87d55ea6b7c74fd
 
-PODFILE CHECKSUM: 5265e733c786a5987c9aa8f08d969fb3ef180aca
+PODFILE CHECKSUM: a5f5d7f5a11db7c7e642078abfcd793cf55602b7
 
 COCOAPODS: 1.14.3

--- a/packages/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/example/ios/Runner.xcodeproj/project.pbxproj
@@ -138,7 +138,7 @@
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
-				F86E63A1E830975F348C297F /* [CP] Copy Pods Resources */,
+				0D7F2239137F5F4DEB04445B /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -197,6 +197,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		0D7F2239137F5F4DEB04445B /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -249,23 +266,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build\n";
-		};
-		F86E63A1E830975F348C297F /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
-			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/packages/example/pubspec.lock
+++ b/packages/example/pubspec.lock
@@ -364,66 +364,65 @@ packages:
     dependency: "direct main"
     description:
       name: rudder_integration_adjust_flutter
-      sha256: "8e4613dd0ab6ffc6692b31b6afce8556746cf2b1fbe1bd2bfc73350e66e3b671"
+      sha256: bf2a4bd6d1890e221e764f20a51199b3ade4caf46fcb58ca63e9d23b452c88fb
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   rudder_integration_amplitude_flutter:
     dependency: "direct main"
     description:
       name: rudder_integration_amplitude_flutter
-      sha256: aebaed5c3ce9681e6f9f1518037c33b737536329538dff02bbee8161c3f41012
+      sha256: "443f7de925be8359f3a762cd9158fb62a319cc83f4976aad518a8e7bc213b516"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   rudder_integration_appcenter_flutter:
     dependency: "direct main"
     description:
       name: rudder_integration_appcenter_flutter
-      sha256: c2c40d1641295c80f8759c8606f3b817c8fbbae7d406f19ab263ddc92b987aea
+      sha256: b31f4326d93c6edc686c6ff91f10a721d1c1aa7da76c000556808b576c19efab
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   rudder_integration_appsflyer_flutter:
     dependency: "direct main"
     description:
       name: rudder_integration_appsflyer_flutter
-      sha256: "72aa58c02064a3b4cb00e0fea4701a693881f781043d5687d1a5d500196622c4"
+      sha256: ffc6c87d9b076c424d211cc76af38eb1ed772ebe241d2f1d0a4d6e656cca4099
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.11"
+    version: "1.1.12"
   rudder_integration_braze_flutter:
     dependency: "direct main"
     description:
       name: rudder_integration_braze_flutter
-      sha256: "4d0aab2bc5730c6f772fff6a67ee869e1189cd724a19482945a63fdce83244c1"
+      sha256: acd4f1f0baa3b6a563e0c59f5d41a25129419bba557c6f27dc2c94a2ce98c809
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   rudder_integration_firebase_flutter:
     dependency: "direct main"
     description:
       name: rudder_integration_firebase_flutter
-      sha256: "8df56016a6597fed8fae95872c8cbacd2e1e060e5aab3a755468d81c08279eb9"
+      sha256: "9f307be4b2c45bf97c5354720d50461b495432e2c8f623af2a389701b2dbfd72"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.1"
+    version: "2.2.2"
   rudder_integration_kochava_flutter:
     dependency: "direct main"
     description:
-      name: rudder_integration_kochava_flutter
-      sha256: "93f8f8ce465f1cc1295567c24d1e3bac17ebb33959d94dd9717ff038103f7741"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.1"
+      path: "../integrations/rudder_integration_kochava_flutter"
+      relative: true
+    source: path
+    version: "1.1.2"
   rudder_integration_leanplum_flutter:
     dependency: "direct main"
     description:
       name: rudder_integration_leanplum_flutter
-      sha256: "6f568b812ec95c6085ef60f512218dc36294196db521030f7e84556b7d4c76ba"
+      sha256: "37012c3ae0512f5a84c510b04e83d699e295ebc9ecf8bf046c278c289503203f"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   rudder_plugin_android:
     dependency: transitive
     description:
@@ -436,18 +435,18 @@ packages:
     dependency: "direct main"
     description:
       name: rudder_plugin_db_encryption
-      sha256: "4d2ab73e07f3bf02c947dbc5136994f95e715c8d92fe3865f4f3d678ce3c537e"
+      sha256: "26337b77c4eec693a7dad778a1e7ec1d33e9d006f38fc0dbdb6ccbfb6f52761c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.5"
+    version: "1.0.6"
   rudder_plugin_ios:
     dependency: transitive
     description:
       name: rudder_plugin_ios
-      sha256: bf2eaf473cdbac42e9b7ecd7fa14600895f3412d289d4fc0091a52b633254795
+      sha256: d4e840eaa0cec63108439db2508b35a69340fc923a6ec76560f9acc340cf71ad
       url: "https://pub.dev"
     source: hosted
-    version: "2.8.0"
+    version: "2.8.1"
   rudder_plugin_web:
     dependency: transitive
     description:
@@ -460,10 +459,10 @@ packages:
     dependency: "direct main"
     description:
       name: rudder_sdk_flutter
-      sha256: "47acaf705a7b03d91ce189ceb66850b5afe3f2a012a874f542d79a60f57e2ca3"
+      sha256: "06c5b784978aba521bb9c191857ed8388437ce4dbc7f04b3990e3c49dafe0cf9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.9.1"
+    version: "2.9.2"
   rudder_sdk_flutter_platform_interface:
     dependency: transitive
     description:

--- a/packages/integrations/rudder_integration_kochava_flutter/ios/rudder_integration_kochava_flutter.podspec
+++ b/packages/integrations/rudder_integration_kochava_flutter/ios/rudder_integration_kochava_flutter.podspec
@@ -19,6 +19,7 @@ Pod::Spec.new do |s|
   s.dependency 'rudder_plugin_ios'
   s.dependency 'Rudder-Kochava', '1.0.1'
   s.platform = :ios, '9.0'
+  s.static_framework = true
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -479,66 +479,66 @@ packages:
     dependency: "direct main"
     description:
       name: rudder_integration_adjust_flutter
-      sha256: "8e4613dd0ab6ffc6692b31b6afce8556746cf2b1fbe1bd2bfc73350e66e3b671"
+      sha256: bf2a4bd6d1890e221e764f20a51199b3ade4caf46fcb58ca63e9d23b452c88fb
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   rudder_integration_amplitude_flutter:
     dependency: "direct main"
     description:
       name: rudder_integration_amplitude_flutter
-      sha256: aebaed5c3ce9681e6f9f1518037c33b737536329538dff02bbee8161c3f41012
+      sha256: "443f7de925be8359f3a762cd9158fb62a319cc83f4976aad518a8e7bc213b516"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   rudder_integration_appcenter_flutter:
     dependency: "direct main"
     description:
       name: rudder_integration_appcenter_flutter
-      sha256: c2c40d1641295c80f8759c8606f3b817c8fbbae7d406f19ab263ddc92b987aea
+      sha256: b31f4326d93c6edc686c6ff91f10a721d1c1aa7da76c000556808b576c19efab
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   rudder_integration_appsflyer_flutter:
     dependency: "direct main"
     description:
       name: rudder_integration_appsflyer_flutter
-      sha256: "72aa58c02064a3b4cb00e0fea4701a693881f781043d5687d1a5d500196622c4"
+      sha256: ffc6c87d9b076c424d211cc76af38eb1ed772ebe241d2f1d0a4d6e656cca4099
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.11"
+    version: "1.1.12"
   rudder_integration_braze_flutter:
     dependency: "direct main"
     description:
       name: rudder_integration_braze_flutter
-      sha256: "4d0aab2bc5730c6f772fff6a67ee869e1189cd724a19482945a63fdce83244c1"
+      sha256: acd4f1f0baa3b6a563e0c59f5d41a25129419bba557c6f27dc2c94a2ce98c809
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   rudder_integration_firebase_flutter:
     dependency: "direct main"
     description:
       name: rudder_integration_firebase_flutter
-      sha256: "8df56016a6597fed8fae95872c8cbacd2e1e060e5aab3a755468d81c08279eb9"
+      sha256: "9f307be4b2c45bf97c5354720d50461b495432e2c8f623af2a389701b2dbfd72"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.1"
+    version: "2.2.2"
   rudder_integration_kochava_flutter:
     dependency: "direct main"
     description:
       name: rudder_integration_kochava_flutter
-      sha256: "93f8f8ce465f1cc1295567c24d1e3bac17ebb33959d94dd9717ff038103f7741"
+      sha256: ab4cd73a5528a17253ad419df4d50fba93dccca7caa37ef65921461cd87b002f
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   rudder_integration_leanplum_flutter:
     dependency: "direct main"
     description:
       name: rudder_integration_leanplum_flutter
-      sha256: "6f568b812ec95c6085ef60f512218dc36294196db521030f7e84556b7d4c76ba"
+      sha256: "37012c3ae0512f5a84c510b04e83d699e295ebc9ecf8bf046c278c289503203f"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   rudder_plugin_android:
     dependency: transitive
     description:
@@ -551,10 +551,10 @@ packages:
     dependency: transitive
     description:
       name: rudder_plugin_ios
-      sha256: bf2eaf473cdbac42e9b7ecd7fa14600895f3412d289d4fc0091a52b633254795
+      sha256: d4e840eaa0cec63108439db2508b35a69340fc923a6ec76560f9acc340cf71ad
       url: "https://pub.dev"
     source: hosted
-    version: "2.8.0"
+    version: "2.8.1"
   rudder_plugin_web:
     dependency: transitive
     description:
@@ -567,10 +567,10 @@ packages:
     dependency: "direct main"
     description:
       name: rudder_sdk_flutter
-      sha256: "47acaf705a7b03d91ce189ceb66850b5afe3f2a012a874f542d79a60f57e2ca3"
+      sha256: "06c5b784978aba521bb9c191857ed8388437ce4dbc7f04b3990e3c49dafe0cf9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.9.1"
+    version: "2.9.2"
   rudder_sdk_flutter_platform_interface:
     dependency: transitive
     description:


### PR DESCRIPTION
## About the issue

Our Flutter Kochava iOS integration throws the following transitive dependency issue if it's installed while having `use_frameworks!` in the Flutter-iOS app Podspec file:
```
[!] The 'Pods-Runner' target has transitive dependencies that include statically linked binaries: (Rudder-Kochava)
```

## About the fix

We attempted to solve this issue by enabling the static framework setting in the Kochava iOS integration.

## About chore changes

For the Flutter sample iOS app, I've changed from `use_frameworks! :linkage=> :static` to `use_frameworks!`. This is to ensure that we perform a default check for the dynamic linkage in the future and prevent this kind of error.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
