### PR TITLE
feat: update minimum version of the native Rudder-Kochava integration

### DIFF
--- a/packages/example/ios/Podfile
+++ b/packages/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-platform :ios, '12.0'
+platform :ios, '12.4'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/packages/example/pubspec.lock
+++ b/packages/example/pubspec.lock
@@ -411,10 +411,11 @@ packages:
   rudder_integration_kochava_flutter:
     dependency: "direct main"
     description:
-      path: "../integrations/rudder_integration_kochava_flutter"
-      relative: true
-    source: path
-    version: "1.1.2"
+      name: rudder_integration_kochava_flutter
+      sha256: b1086315f502732ffb4afbacb28a362e63380db003c0d918a20a4d9a5733a094
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.3"
   rudder_integration_leanplum_flutter:
     dependency: "direct main"
     description:

--- a/packages/integrations/rudder_integration_kochava_flutter/android/build.gradle
+++ b/packages/integrations/rudder_integration_kochava_flutter/android/build.gradle
@@ -36,8 +36,8 @@ android {
 
 dependencies {
     // Rudder Android Core SDK Dependencies
-    implementation 'com.rudderstack.android.sdk:core:[1.21.3 2.0.0)'
+    implementation 'com.rudderstack.android.sdk:core:[1.23.1, 2.0.0)'
     implementation project(path: ':rudder_plugin_android')
     // RudderStack Kochava-SDK
-    implementation 'com.rudderstack.android.integration:kochava:1.0.1'
+    implementation 'com.rudderstack.android.integration:kochava:[2.0.0,)'
 }

--- a/packages/integrations/rudder_integration_kochava_flutter/ios/rudder_integration_kochava_flutter.podspec
+++ b/packages/integrations/rudder_integration_kochava_flutter/ios/rudder_integration_kochava_flutter.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.dependency 'Flutter'
   s.dependency 'rudder_plugin_ios'
   s.dependency 'Rudder-Kochava', '>= 2.0.0'
-  s.platform = :ios, '9.0'
+  s.platform = :ios, '12.4'
   s.static_framework = true
 
   # Flutter.framework does not contain a i386 slice.

--- a/packages/integrations/rudder_integration_kochava_flutter/ios/rudder_integration_kochava_flutter.podspec
+++ b/packages/integrations/rudder_integration_kochava_flutter/ios/rudder_integration_kochava_flutter.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.dependency 'rudder_plugin_ios'
-  s.dependency 'Rudder-Kochava', '1.0.1'
+  s.dependency 'Rudder-Kochava', '>= 2.0.0'
   s.platform = :ios, '9.0'
   s.static_framework = true
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -527,10 +527,10 @@ packages:
     dependency: "direct main"
     description:
       name: rudder_integration_kochava_flutter
-      sha256: ab4cd73a5528a17253ad419df4d50fba93dccca7caa37ef65921461cd87b002f
+      sha256: b1086315f502732ffb4afbacb28a362e63380db003c0d918a20a4d9a5733a094
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.3"
   rudder_integration_leanplum_flutter:
     dependency: "direct main"
     description:


### PR DESCRIPTION
## Description of the change

- Updated the minimum `Rudder-Kochava` Android SDK version to `2.0.0` and no upper limit.
- Updated the minimum `Rudder-Kochava` iOS SDK version to `2.0.0` and no upper limit.
- Updated the minimum Rudder `Android` SDK version to `1.23.1`.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
