### PR TITLE
feat!: web config options update to the latest

### DIFF
--- a/packages/example/lib/home_screen.dart
+++ b/packages/example/lib/home_screen.dart
@@ -52,7 +52,7 @@ class HomeScreenState extends State<HomeScreen> {
     WebConfig wc = WebConfig(
       storage: StorageOpts(type: StorageType.localStorage, entries: {
         UserSessionKey.anonymousId:
-            LoadOptionStorageEntry(type: StorageType.cookieStorage)
+            StorageEntry(type: StorageType.cookieStorage)
       }),
       lockIntegrationsVersion: true,
       lockPluginsVersion: true,

--- a/packages/example/lib/home_screen.dart
+++ b/packages/example/lib/home_screen.dart
@@ -50,12 +50,25 @@ class HomeScreenState extends State<HomeScreen> {
         recordScreenViews: true,
         collectDeviceId: false);
     WebConfig wc = WebConfig(
-        autoSessionTracking: true,
-        sessionTimeoutInMillis: 10000,
-        storage: StorageOpts(type: StorageType.localStorage, entries: {
-          UserSessionKey.anonymousId:
-              LoadOptionStorageEntry(type: StorageType.cookieStorage)
-        }));
+      storage: StorageOpts(type: StorageType.localStorage, entries: {
+        UserSessionKey.anonymousId:
+            LoadOptionStorageEntry(type: StorageType.cookieStorage)
+      }),
+      lockIntegrationsVersion: true,
+      lockPluginsVersion: true,
+      // queueOptions: QueueOpts(
+      //   maxRetryDelay: 60000,
+      //   minRetryDelay: 1000,
+      //   backoffFactor: 2),
+      // useBeacon: true,
+      // beaconQueueOptions: BeaconQueueOpts(
+      //     maxItems: 2, flushQueueInterval: 5000),
+      // destSDKBaseURL: "https://cdn.rudderlabs.com/v1.1/js-integrations",
+      // pluginsSDKBaseURL: "https://cdn.rudderlabs.com/v3/modern/plugins/rsa-plugins.js",
+      //  sessions: SessionOpts( autoTrack: true, timeout: 2 * 60 * 1000),
+      //  uaChTrackLevel: UaChTrackLevel.defaultLevel,
+      // plugins: [PluginName.BeaconQueue, PluginName.DeviceModeDestinations],
+    );
     RudderConfigBuilder builder = RudderConfigBuilder();
     builder
       ..withFactory(RudderIntegrationKochavaFlutter())

--- a/packages/example/lib/home_screen.dart
+++ b/packages/example/lib/home_screen.dart
@@ -49,8 +49,13 @@ class HomeScreenState extends State<HomeScreen> {
         gzip: false,
         recordScreenViews: true,
         collectDeviceId: false);
-    WebConfig wc =
-        WebConfig(autoSessionTracking: true, sessionTimeoutInMillis: 10000);
+    WebConfig wc = WebConfig(
+        autoSessionTracking: true,
+        sessionTimeoutInMillis: 10000,
+        storage: StorageOpts(type: StorageType.localStorage, entries: {
+          UserSessionKey.anonymousId:
+              LoadOptionStorageEntry(type: StorageType.cookieStorage)
+        }));
     RudderConfigBuilder builder = RudderConfigBuilder();
     builder
       ..withFactory(RudderIntegrationKochavaFlutter())

--- a/packages/example/lib/home_screen.dart
+++ b/packages/example/lib/home_screen.dart
@@ -56,18 +56,6 @@ class HomeScreenState extends State<HomeScreen> {
       }),
       lockIntegrationsVersion: true,
       lockPluginsVersion: true,
-      // queueOptions: QueueOpts(
-      //   maxRetryDelay: 60000,
-      //   minRetryDelay: 1000,
-      //   backoffFactor: 2),
-      // useBeacon: true,
-      // beaconQueueOptions: BeaconQueueOpts(
-      //     maxItems: 2, flushQueueInterval: 5000),
-      // destSDKBaseURL: "https://cdn.rudderlabs.com/v1.1/js-integrations",
-      // pluginsSDKBaseURL: "https://cdn.rudderlabs.com/v3/modern/plugins/rsa-plugins.js",
-      //  sessions: SessionOpts( autoTrack: true, timeout: 2 * 60 * 1000),
-      //  uaChTrackLevel: UaChTrackLevel.defaultLevel,
-      // plugins: [PluginName.BeaconQueue, PluginName.DeviceModeDestinations],
     );
     RudderConfigBuilder builder = RudderConfigBuilder();
     builder

--- a/packages/example/pubspec.lock
+++ b/packages/example/pubspec.lock
@@ -236,26 +236,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -284,18 +284,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.15.0"
   package_config:
     dependency: transitive
     description:
@@ -366,98 +366,98 @@ packages:
       path: "../integrations/rudder_integration_adjust_flutter"
       relative: true
     source: path
-    version: "1.2.2"
+    version: "1.3.0"
   rudder_integration_amplitude_flutter:
     dependency: "direct main"
     description:
       path: "../integrations/rudder_integration_amplitude_flutter"
       relative: true
     source: path
-    version: "1.2.2"
+    version: "1.3.0"
   rudder_integration_appcenter_flutter:
     dependency: "direct main"
     description:
       path: "../integrations/rudder_integration_appcenter_flutter"
       relative: true
     source: path
-    version: "1.3.2"
+    version: "1.4.0"
   rudder_integration_appsflyer_flutter:
     dependency: "direct main"
     description:
       path: "../integrations/rudder_integration_appsflyer_flutter"
       relative: true
     source: path
-    version: "1.1.12"
+    version: "1.1.13"
   rudder_integration_braze_flutter:
     dependency: "direct main"
     description:
       path: "../integrations/rudder_integration_braze_flutter"
       relative: true
     source: path
-    version: "1.2.2"
+    version: "1.3.0"
   rudder_integration_firebase_flutter:
     dependency: "direct main"
     description:
       path: "../integrations/rudder_integration_firebase_flutter"
       relative: true
     source: path
-    version: "2.2.2"
+    version: "2.3.0"
   rudder_integration_kochava_flutter:
     dependency: "direct main"
     description:
       path: "../integrations/rudder_integration_kochava_flutter"
       relative: true
     source: path
-    version: "1.1.3"
+    version: "1.2.0"
   rudder_integration_leanplum_flutter:
     dependency: "direct main"
     description:
       path: "../integrations/rudder_integration_leanplum_flutter"
       relative: true
     source: path
-    version: "1.2.2"
+    version: "1.3.0"
   rudder_plugin_android:
     dependency: "direct overridden"
     description:
       path: "../plugins/rudder_plugin_android"
       relative: true
     source: path
-    version: "2.8.0"
+    version: "2.9.0"
   rudder_plugin_db_encryption:
     dependency: "direct main"
     description:
       path: "../plugins/rudder_plugin_db_encryption"
       relative: true
     source: path
-    version: "1.0.6"
+    version: "1.1.0"
   rudder_plugin_ios:
     dependency: "direct overridden"
     description:
       path: "../plugins/rudder_plugin_ios"
       relative: true
     source: path
-    version: "2.8.1"
+    version: "2.9.0"
   rudder_plugin_web:
     dependency: "direct overridden"
     description:
       path: "../plugins/rudder_plugin_web"
       relative: true
     source: path
-    version: "2.7.0"
+    version: "2.8.0"
   rudder_sdk_flutter:
     dependency: "direct main"
     description:
       path: "../plugins/rudder_plugin"
       relative: true
     source: path
-    version: "2.9.2"
+    version: "2.10.0"
   rudder_sdk_flutter_platform_interface:
     dependency: "direct overridden"
     description:
       path: "../plugins/rudder_plugin_interface"
       relative: true
     source: path
-    version: "2.8.0"
+    version: "2.9.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -507,10 +507,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:
@@ -539,10 +539,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.5"
   watcher:
     dependency: transitive
     description:
@@ -568,4 +568,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=3.2.0-0 <4.0.0"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/packages/integrations/rudder_integration_adjust_flutter/pubspec.lock
+++ b/packages/integrations/rudder_integration_adjust_flutter/pubspec.lock
@@ -220,26 +220,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -268,18 +268,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.15.0"
   package_config:
     dependency: transitive
     description:
@@ -350,35 +350,35 @@ packages:
       path: "../../plugins/rudder_plugin_android"
       relative: true
     source: path
-    version: "2.8.0"
+    version: "2.9.0"
   rudder_plugin_ios:
     dependency: "direct overridden"
     description:
       path: "../../plugins/rudder_plugin_ios"
       relative: true
     source: path
-    version: "2.8.1"
+    version: "2.9.0"
   rudder_plugin_web:
     dependency: "direct overridden"
     description:
       path: "../../plugins/rudder_plugin_web"
       relative: true
     source: path
-    version: "2.7.0"
+    version: "2.8.0"
   rudder_sdk_flutter:
     dependency: "direct main"
     description:
       path: "../../plugins/rudder_plugin"
       relative: true
     source: path
-    version: "2.9.2"
+    version: "2.10.0"
   rudder_sdk_flutter_platform_interface:
     dependency: "direct main"
     description:
       path: "../../plugins/rudder_plugin_interface"
       relative: true
     source: path
-    version: "2.8.0"
+    version: "2.9.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -428,10 +428,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:
@@ -460,10 +460,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.5"
   watcher:
     dependency: transitive
     description:
@@ -489,5 +489,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=3.2.0-0 <4.0.0"
-  flutter: ">=2.5.0"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/packages/integrations/rudder_integration_amplitude_flutter/pubspec.lock
+++ b/packages/integrations/rudder_integration_amplitude_flutter/pubspec.lock
@@ -220,26 +220,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -268,18 +268,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.15.0"
   package_config:
     dependency: transitive
     description:
@@ -350,35 +350,35 @@ packages:
       path: "../../plugins/rudder_plugin_android"
       relative: true
     source: path
-    version: "2.8.0"
+    version: "2.9.0"
   rudder_plugin_ios:
     dependency: "direct overridden"
     description:
       path: "../../plugins/rudder_plugin_ios"
       relative: true
     source: path
-    version: "2.8.1"
+    version: "2.9.0"
   rudder_plugin_web:
     dependency: "direct overridden"
     description:
       path: "../../plugins/rudder_plugin_web"
       relative: true
     source: path
-    version: "2.7.0"
+    version: "2.8.0"
   rudder_sdk_flutter:
     dependency: "direct main"
     description:
       path: "../../plugins/rudder_plugin"
       relative: true
     source: path
-    version: "2.9.2"
+    version: "2.10.0"
   rudder_sdk_flutter_platform_interface:
     dependency: "direct main"
     description:
       path: "../../plugins/rudder_plugin_interface"
       relative: true
     source: path
-    version: "2.8.0"
+    version: "2.9.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -428,10 +428,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:
@@ -460,10 +460,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.5"
   watcher:
     dependency: transitive
     description:
@@ -489,5 +489,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=3.2.0-0 <4.0.0"
-  flutter: ">=2.5.0"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/packages/integrations/rudder_integration_appcenter_flutter/pubspec.lock
+++ b/packages/integrations/rudder_integration_appcenter_flutter/pubspec.lock
@@ -220,26 +220,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -268,18 +268,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.15.0"
   package_config:
     dependency: transitive
     description:
@@ -350,35 +350,35 @@ packages:
       path: "../../plugins/rudder_plugin_android"
       relative: true
     source: path
-    version: "2.8.0"
+    version: "2.9.0"
   rudder_plugin_ios:
     dependency: "direct overridden"
     description:
       path: "../../plugins/rudder_plugin_ios"
       relative: true
     source: path
-    version: "2.8.1"
+    version: "2.9.0"
   rudder_plugin_web:
     dependency: "direct overridden"
     description:
       path: "../../plugins/rudder_plugin_web"
       relative: true
     source: path
-    version: "2.7.0"
+    version: "2.8.0"
   rudder_sdk_flutter:
     dependency: "direct main"
     description:
       path: "../../plugins/rudder_plugin"
       relative: true
     source: path
-    version: "2.9.2"
+    version: "2.10.0"
   rudder_sdk_flutter_platform_interface:
     dependency: "direct main"
     description:
       path: "../../plugins/rudder_plugin_interface"
       relative: true
     source: path
-    version: "2.8.0"
+    version: "2.9.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -428,10 +428,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:
@@ -460,10 +460,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.5"
   watcher:
     dependency: transitive
     description:
@@ -489,5 +489,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=3.2.0-0 <4.0.0"
-  flutter: ">=2.5.0"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/packages/integrations/rudder_integration_braze_flutter/pubspec.lock
+++ b/packages/integrations/rudder_integration_braze_flutter/pubspec.lock
@@ -220,26 +220,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -268,18 +268,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.15.0"
   package_config:
     dependency: transitive
     description:
@@ -350,35 +350,35 @@ packages:
       path: "../../plugins/rudder_plugin_android"
       relative: true
     source: path
-    version: "2.8.0"
+    version: "2.9.0"
   rudder_plugin_ios:
     dependency: "direct overridden"
     description:
       path: "../../plugins/rudder_plugin_ios"
       relative: true
     source: path
-    version: "2.8.1"
+    version: "2.9.0"
   rudder_plugin_web:
     dependency: "direct overridden"
     description:
       path: "../../plugins/rudder_plugin_web"
       relative: true
     source: path
-    version: "2.7.0"
+    version: "2.8.0"
   rudder_sdk_flutter:
     dependency: "direct main"
     description:
       path: "../../plugins/rudder_plugin"
       relative: true
     source: path
-    version: "2.9.2"
+    version: "2.10.0"
   rudder_sdk_flutter_platform_interface:
     dependency: "direct main"
     description:
       path: "../../plugins/rudder_plugin_interface"
       relative: true
     source: path
-    version: "2.8.0"
+    version: "2.9.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -428,10 +428,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:
@@ -460,10 +460,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.5"
   watcher:
     dependency: transitive
     description:
@@ -489,5 +489,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=3.2.0-0 <4.0.0"
-  flutter: ">=2.5.0"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/packages/integrations/rudder_integration_firebase_flutter/pubspec.lock
+++ b/packages/integrations/rudder_integration_firebase_flutter/pubspec.lock
@@ -220,26 +220,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -268,18 +268,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.15.0"
   package_config:
     dependency: transitive
     description:
@@ -350,35 +350,35 @@ packages:
       path: "../../plugins/rudder_plugin_android"
       relative: true
     source: path
-    version: "2.8.0"
+    version: "2.9.0"
   rudder_plugin_ios:
     dependency: "direct overridden"
     description:
       path: "../../plugins/rudder_plugin_ios"
       relative: true
     source: path
-    version: "2.8.1"
+    version: "2.9.0"
   rudder_plugin_web:
     dependency: "direct overridden"
     description:
       path: "../../plugins/rudder_plugin_web"
       relative: true
     source: path
-    version: "2.7.0"
+    version: "2.8.0"
   rudder_sdk_flutter:
     dependency: "direct main"
     description:
       path: "../../plugins/rudder_plugin"
       relative: true
     source: path
-    version: "2.9.2"
+    version: "2.10.0"
   rudder_sdk_flutter_platform_interface:
     dependency: "direct main"
     description:
       path: "../../plugins/rudder_plugin_interface"
       relative: true
     source: path
-    version: "2.8.0"
+    version: "2.9.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -428,10 +428,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:
@@ -460,10 +460,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.5"
   watcher:
     dependency: transitive
     description:
@@ -489,5 +489,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=3.2.0-0 <4.0.0"
-  flutter: ">=2.5.0"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/packages/integrations/rudder_integration_kochava_flutter/pubspec.lock
+++ b/packages/integrations/rudder_integration_kochava_flutter/pubspec.lock
@@ -220,26 +220,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -268,18 +268,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.15.0"
   package_config:
     dependency: transitive
     description:
@@ -350,35 +350,35 @@ packages:
       path: "../../plugins/rudder_plugin_android"
       relative: true
     source: path
-    version: "2.8.0"
+    version: "2.9.0"
   rudder_plugin_ios:
     dependency: "direct overridden"
     description:
       path: "../../plugins/rudder_plugin_ios"
       relative: true
     source: path
-    version: "2.8.1"
+    version: "2.9.0"
   rudder_plugin_web:
     dependency: "direct overridden"
     description:
       path: "../../plugins/rudder_plugin_web"
       relative: true
     source: path
-    version: "2.7.0"
+    version: "2.8.0"
   rudder_sdk_flutter:
     dependency: "direct main"
     description:
       path: "../../plugins/rudder_plugin"
       relative: true
     source: path
-    version: "2.9.2"
+    version: "2.10.0"
   rudder_sdk_flutter_platform_interface:
     dependency: "direct main"
     description:
       path: "../../plugins/rudder_plugin_interface"
       relative: true
     source: path
-    version: "2.8.0"
+    version: "2.9.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -428,10 +428,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:
@@ -460,10 +460,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.5"
   watcher:
     dependency: transitive
     description:
@@ -489,5 +489,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.2.0-0 <4.0.0"
-  flutter: ">=2.5.0"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/packages/integrations/rudder_integration_leanplum_flutter/pubspec.lock
+++ b/packages/integrations/rudder_integration_leanplum_flutter/pubspec.lock
@@ -220,26 +220,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -268,18 +268,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.15.0"
   package_config:
     dependency: transitive
     description:
@@ -350,35 +350,35 @@ packages:
       path: "../../plugins/rudder_plugin_android"
       relative: true
     source: path
-    version: "2.8.0"
+    version: "2.9.0"
   rudder_plugin_ios:
     dependency: "direct overridden"
     description:
       path: "../../plugins/rudder_plugin_ios"
       relative: true
     source: path
-    version: "2.8.1"
+    version: "2.9.0"
   rudder_plugin_web:
     dependency: "direct overridden"
     description:
       path: "../../plugins/rudder_plugin_web"
       relative: true
     source: path
-    version: "2.7.0"
+    version: "2.8.0"
   rudder_sdk_flutter:
     dependency: "direct main"
     description:
       path: "../../plugins/rudder_plugin"
       relative: true
     source: path
-    version: "2.9.2"
+    version: "2.10.0"
   rudder_sdk_flutter_platform_interface:
     dependency: "direct main"
     description:
       path: "../../plugins/rudder_plugin_interface"
       relative: true
     source: path
-    version: "2.8.0"
+    version: "2.9.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -428,10 +428,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:
@@ -460,10 +460,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.5"
   watcher:
     dependency: transitive
     description:
@@ -489,5 +489,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=3.2.0-0 <4.0.0"
-  flutter: ">=2.5.0"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/packages/plugins/rudder_plugin/pubspec.lock
+++ b/packages/plugins/rudder_plugin/pubspec.lock
@@ -220,26 +220,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -268,18 +268,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.15.0"
   package_config:
     dependency: transitive
     description:
@@ -350,28 +350,28 @@ packages:
       path: "../rudder_plugin_android"
       relative: true
     source: path
-    version: "2.8.0"
+    version: "2.9.0"
   rudder_plugin_ios:
     dependency: "direct main"
     description:
       path: "../rudder_plugin_ios"
       relative: true
     source: path
-    version: "2.8.1"
+    version: "2.9.0"
   rudder_plugin_web:
     dependency: "direct main"
     description:
       path: "../rudder_plugin_web"
       relative: true
     source: path
-    version: "2.7.0"
+    version: "2.8.0"
   rudder_sdk_flutter_platform_interface:
     dependency: "direct main"
     description:
       path: "../rudder_plugin_interface"
       relative: true
     source: path
-    version: "2.8.0"
+    version: "2.9.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -421,10 +421,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:
@@ -453,10 +453,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.5"
   watcher:
     dependency: transitive
     description:
@@ -482,5 +482,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=3.2.0-0 <4.0.0"
-  flutter: ">=2.0.0"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/packages/plugins/rudder_plugin_android/pubspec.lock
+++ b/packages/plugins/rudder_plugin_android/pubspec.lock
@@ -207,26 +207,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -255,18 +255,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.15.0"
   package_config:
     dependency: transitive
     description:
@@ -337,7 +337,7 @@ packages:
       path: "../rudder_plugin_interface"
       relative: true
     source: path
-    version: "2.8.0"
+    version: "2.9.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -387,10 +387,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:
@@ -419,10 +419,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.5"
   watcher:
     dependency: transitive
     description:
@@ -448,5 +448,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=3.2.0-0 <4.0.0"
-  flutter: ">=2.0.0"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/packages/plugins/rudder_plugin_interface/lib/platform.dart
+++ b/packages/plugins/rudder_plugin_interface/lib/platform.dart
@@ -11,3 +11,4 @@ export 'src/models/rudder_integration.dart';
 export 'src/models/rudder_option.dart';
 export 'src/models/rudder_property.dart';
 export 'src/models/rudder_traits.dart';
+export 'src/models/web_config_interfaces/index.dart';

--- a/packages/plugins/rudder_plugin_interface/lib/src/constants.dart
+++ b/packages/plugins/rudder_plugin_interface/lib/src/constants.dart
@@ -60,6 +60,9 @@ class Constants {
   static const int DEFAULT_BACK_OFF_FACTOR = 2;
   static const int DEFAULT_MAX_ATTEMPTS = 10;
   static const int DEFAULT_MAX_ITEMS = 100;
+  static const bool DEFAULT_LOCK_INTEGRATIONS_VERSION = false;
+  static const bool DEFAULT_LOCK_PLUGINS_VERSION = false;
+  static const bool DEFAULT_POLYFILL_IF_REQUIRED = false;
 
   //BEACON
   static const int DEFAULT_BEACON_FLUSH_QUEUE_INTERVAL = 600000;

--- a/packages/plugins/rudder_plugin_interface/lib/src/constants.dart
+++ b/packages/plugins/rudder_plugin_interface/lib/src/constants.dart
@@ -2,7 +2,6 @@
  * Default value holder class
  * */
 import 'enums.dart';
-import './models/web_config_interfaces/index.dart';
 
 class Constants {
   // how often config should be fetched from the server (in hours) (2 hrs by default)
@@ -51,27 +50,4 @@ class Constants {
 
   static const DataResidencyServer DEFAULT_DATA_RESIDENCY_SERVER =
       DataResidencyServer.US;
-
-  //web load integration
-  static const bool DEFAULT_LOAD_INTEGRATION = true;
-  static const bool DEFAULT_SECURE_COOKIE = false;
-  static const bool DEFAULT_USE_BEACON = false;
-  static const int DEFAULT_MAX_RETRY_DELAY = 360000;
-  static const int DEFAULT_MIN_RETRY_DELAY = 1000;
-  static const int DEFAULT_BACK_OFF_FACTOR = 2;
-  static const int DEFAULT_MAX_ATTEMPTS = 10;
-  static const int DEFAULT_MAX_ITEMS = 100;
-  static const bool DEFAULT_LOCK_INTEGRATIONS_VERSION = false;
-  static const bool DEFAULT_LOCK_PLUGINS_VERSION = false;
-  static const bool DEFAULT_POLYFILL_IF_REQUIRED = true;
-  static const UaChTrackLevel DEFAULT_UACH_TRACK_LEVEL = UaChTrackLevel.none;
-  static const bool DEFAULT_USE_GLOBAL_INTEGRATIONS_CONFIG_IN_EVENTS = false;
-  static const bool DEFAULT_BUFFER_DATA_PLANE_EVENTS_UNTIL_READY = false;
-  static const int DEFAULT_DATA_PLANE_EVENTS_BUFFER_TIMEOUT =
-      10 * 1000; // 10 seconds
-  static const bool DEFAULT_USE_SERVER_SIDE_COOKIES = false;
-
-  //BEACON
-  static const int DEFAULT_BEACON_FLUSH_QUEUE_INTERVAL = 600000;
-  static const int DEFAULT_BEACON_MAX_ITEMS = 10;
 }

--- a/packages/plugins/rudder_plugin_interface/lib/src/constants.dart
+++ b/packages/plugins/rudder_plugin_interface/lib/src/constants.dart
@@ -2,6 +2,7 @@
  * Default value holder class
  * */
 import 'enums.dart';
+import './models/web_config_interfaces/index.dart';
 
 class Constants {
   // how often config should be fetched from the server (in hours) (2 hrs by default)
@@ -62,12 +63,15 @@ class Constants {
   static const int DEFAULT_MAX_ITEMS = 100;
   static const bool DEFAULT_LOCK_INTEGRATIONS_VERSION = false;
   static const bool DEFAULT_LOCK_PLUGINS_VERSION = false;
-  static const bool DEFAULT_POLYFILL_IF_REQUIRED = false;
+  static const bool DEFAULT_POLYFILL_IF_REQUIRED = true;
+  static const UaChTrackLevel DEFAULT_UACH_TRACK_LEVEL = UaChTrackLevel.none;
+  static const bool DEFAULT_USE_GLOBAL_INTEGRATIONS_CONFIG_IN_EVENTS = false;
+  static const bool DEFAULT_BUFFER_DATA_PLANE_EVENTS_UNTIL_READY = false;
+  static const int DEFAULT_DATA_PLANE_EVENTS_BUFFER_TIMEOUT =
+      10 * 1000; // 10 seconds
+  static const bool DEFAULT_USE_SERVER_SIDE_COOKIES = false;
 
   //BEACON
   static const int DEFAULT_BEACON_FLUSH_QUEUE_INTERVAL = 600000;
   static const int DEFAULT_BEACON_MAX_ITEMS = 10;
-
-  static const String DEFAULT_DESTINATION_SDK_BASE_URL =
-      "https://cdn.rudderlabs.com/v1.1/js-integrations";
 }

--- a/packages/plugins/rudder_plugin_interface/lib/src/models/rudder_config.dart
+++ b/packages/plugins/rudder_plugin_interface/lib/src/models/rudder_config.dart
@@ -167,6 +167,11 @@ class RudderConfig {
       _webConfigMap["queueOptions"] = queueOpts;
 
       _webConfigMap["useBeacon"] = webConfig.useBeacon;
+      _webConfigMap["lockIntegrationsVersion"] =
+          webConfig.lockIntegrationsVersion;
+      _webConfigMap["lockPluginsVersion"] = webConfig.lockPluginsVersion;
+      _webConfigMap["polyfillIfRequired"] = webConfig.polyfillIfRequired;
+
       //beacon queue opts if available
       if (webConfig.useBeacon) {
         beaconOpts["maxItems"] =
@@ -189,6 +194,15 @@ class RudderConfig {
         _webConfigMap["destSDKBaseUrl"] =
             Constants.DEFAULT_DESTINATION_SDK_BASE_URL;
       }
+      if (webConfig.pluginsSDKBaseURL != null) {
+        if (Utils.isValidUrl(webConfig.pluginsSDKBaseURL as String)) {
+          _webConfigMap["pluginsSDKBaseURL"] = webConfig.pluginsSDKBaseURL;
+        } else {
+          RudderLogger.logWarn(
+              "Plugin SDK Base Url is not valid, using default");
+        }
+      }
+
       sessionOpts['autoTrack'] = webConfig.autoSessionTracking;
       if (webConfig.sessionTimeoutInMillis < 0) {
         RudderLogger.logError("invalid sessionTimeoutInMillis. Set to default");
@@ -197,6 +211,10 @@ class RudderConfig {
         sessionOpts['timeout'] = webConfig.sessionTimeoutInMillis;
       }
       _webConfigMap["sessions"] = sessionOpts;
+
+      if (webConfig.storage != null) {
+        _webConfigMap["storage"] = webConfig.storage?.toMap();
+      }
     }
   }
 

--- a/packages/plugins/rudder_plugin_interface/lib/src/models/rudder_config.dart
+++ b/packages/plugins/rudder_plugin_interface/lib/src/models/rudder_config.dart
@@ -168,7 +168,7 @@ class RudderConfig {
         _webConfigMap["queueOptions"] = webConfig.queueOptions?.toMap();
       }
       //beacon queue opts if available
-      if (webConfig.useBeacon && webConfig.beaconQueueOptions != null) {
+      if (webConfig.useBeacon != null && webConfig.beaconQueueOptions != null) {
         _webConfigMap["beaconQueueOptions"] =
             webConfig.beaconQueueOptions?.toMap();
       }
@@ -181,19 +181,10 @@ class RudderConfig {
         _webConfigMap["sessions"] = webConfig.sessions?.toMap();
       }
       if (webConfig.destSDKBaseURL != null) {
-        if (Utils.isValidUrl(webConfig.destSDKBaseURL as String)) {
-          _webConfigMap["destSDKBaseURL"] = webConfig.destSDKBaseURL;
-        } else {
-          RudderLogger.logWarn("Dest SDK Base Url is not valid, using default");
-        }
+        _webConfigMap["destSDKBaseURL"] = webConfig.destSDKBaseURL;
       }
       if (webConfig.pluginsSDKBaseURL != null) {
-        if (Utils.isValidUrl(webConfig.pluginsSDKBaseURL as String)) {
-          _webConfigMap["pluginsSDKBaseURL"] = webConfig.pluginsSDKBaseURL;
-        } else {
-          RudderLogger.logWarn(
-              "Plugin SDK Base Url is not valid, using default");
-        }
+        _webConfigMap["pluginsSDKBaseURL"] = webConfig.pluginsSDKBaseURL;
       }
       if (webConfig.storage != null) {
         _webConfigMap["storage"] = webConfig.storage?.toMap();
@@ -217,19 +208,10 @@ class RudderConfig {
         _webConfigMap["plugins"] = webConfig.plugins;
       }
       if (webConfig.polyfillURL != null) {
-        if (Utils.isValidUrl(webConfig.polyfillURL as String)) {
-          _webConfigMap["polyfillURL"] = webConfig.polyfillURL;
-        } else {
-          RudderLogger.logWarn(
-              "Provided Polyfill Url is not valid, using default");
-        }
+        _webConfigMap["polyfillURL"] = webConfig.polyfillURL;
       }
       if (webConfig.preConsent != null) {
         _webConfigMap["preConsent"] = webConfig.preConsent?.toMap();
-      }
-      if (webConfig.transportMode != null) {
-        _webConfigMap["transportMode"] =
-            webConfig.transportMode.toString().split('.').last;
       }
       if (webConfig.externalAnonymousIdCookieName != null) {
         _webConfigMap["externalAnonymousIdCookieName"] =

--- a/packages/plugins/rudder_plugin_interface/lib/src/models/rudder_web_config.dart
+++ b/packages/plugins/rudder_plugin_interface/lib/src/models/rudder_web_config.dart
@@ -1,17 +1,16 @@
-import '../constants.dart';
 import './web_config_interfaces/index.dart';
 
 class WebConfig {
   ///web default true
-  final bool _loadIntegration;
+  final bool? _loadIntegration;
 
   ///web default false
-  final bool _secureCookie;
+  final bool? _secureCookie;
 
   final QueueOpts? _queueOptions;
 
   ///web default false
-  final bool _useBeacon;
+  final bool? _useBeacon;
 
   final BeaconQueueOpts? _beaconQueueOptions;
 
@@ -23,13 +22,13 @@ class WebConfig {
   final String? _pluginsSDKBaseURL;
 
   /// default false
-  final bool _lockIntegrationsVersion;
+  final bool? _lockIntegrationsVersion;
 
   /// default false
-  final bool _lockPluginsVersion;
+  final bool? _lockPluginsVersion;
 
   /// default false
-  final bool _polyfillIfRequired;
+  final bool? _polyfillIfRequired;
 
   final StorageOpts? _storage;
 
@@ -49,15 +48,13 @@ class WebConfig {
 
   final String? _polyfillURL;
 
-  final bool _useGlobalIntegrationsConfigInEvents;
+  final bool? _useGlobalIntegrationsConfigInEvents;
 
-  final bool _bufferDataPlaneEventsUntilReady;
+  final bool? _bufferDataPlaneEventsUntilReady;
 
-  final int _dataPlaneEventsBufferTimeout;
+  final int? _dataPlaneEventsBufferTimeout;
 
   final PreConsentOptions? _preConsent;
-
-  final EventsTransportMode? _transportMode;
 
   final ConsentManagementOptions? _consentManagement;
 
@@ -65,25 +62,22 @@ class WebConfig {
 
   final String? _externalAnonymousIdCookieName;
 
-  final bool _useServerSideCookies;
+  final bool? _useServerSideCookies;
 
   final String? _dataServiceEndpoint;
 
   WebConfig(
-      {loadIntegration = Constants.DEFAULT_LOAD_INTEGRATION,
-      secureCookie = Constants.DEFAULT_SECURE_COOKIE,
-      useBeacon = Constants.DEFAULT_USE_BEACON,
-      lockIntegrationsVersion = Constants.DEFAULT_LOCK_INTEGRATIONS_VERSION,
-      lockPluginsVersion = Constants.DEFAULT_LOCK_PLUGINS_VERSION,
-      polyfillIfRequired = Constants.DEFAULT_POLYFILL_IF_REQUIRED,
-      uaChTrackLevel = Constants.DEFAULT_UACH_TRACK_LEVEL,
-      useGlobalIntegrationsConfigInEvents =
-          Constants.DEFAULT_USE_GLOBAL_INTEGRATIONS_CONFIG_IN_EVENTS,
-      bufferDataPlaneEventsUntilReady =
-          Constants.DEFAULT_BUFFER_DATA_PLANE_EVENTS_UNTIL_READY,
-      dataPlaneEventsBufferTimeout =
-          Constants.DEFAULT_DATA_PLANE_EVENTS_BUFFER_TIMEOUT,
-      useServerSideCookies = Constants.DEFAULT_USE_SERVER_SIDE_COOKIES,
+      {loadIntegration,
+      secureCookie,
+      useBeacon,
+      lockIntegrationsVersion,
+      lockPluginsVersion,
+      polyfillIfRequired,
+      uaChTrackLevel,
+      useGlobalIntegrationsConfigInEvents,
+      bufferDataPlaneEventsUntilReady,
+      dataPlaneEventsBufferTimeout,
+      useServerSideCookies,
       destSDKBaseURL,
       pluginsSDKBaseURL,
       storage,
@@ -95,7 +89,6 @@ class WebConfig {
       plugins,
       polyfillURL,
       preConsent,
-      transportMode,
       consentManagement,
       sameDomainCookiesOnly,
       externalAnonymousIdCookieName,
@@ -126,7 +119,6 @@ class WebConfig {
         _bufferDataPlaneEventsUntilReady = bufferDataPlaneEventsUntilReady,
         _dataPlaneEventsBufferTimeout = dataPlaneEventsBufferTimeout,
         _preConsent = preConsent,
-        _transportMode = transportMode,
         _consentManagement = consentManagement,
         _sameDomainCookiesOnly = sameDomainCookiesOnly,
         _externalAnonymousIdCookieName = externalAnonymousIdCookieName,
@@ -137,17 +129,17 @@ class WebConfig {
 
   String? get destSDKBaseURL => _destSDKBaseURL;
 
-  bool get useBeacon => _useBeacon;
+  bool? get useBeacon => _useBeacon;
 
-  bool get lockIntegrationsVersion => _lockIntegrationsVersion;
+  bool? get lockIntegrationsVersion => _lockIntegrationsVersion;
 
-  bool get lockPluginsVersion => _lockPluginsVersion;
+  bool? get lockPluginsVersion => _lockPluginsVersion;
 
-  bool get polyfillIfRequired => _polyfillIfRequired;
+  bool? get polyfillIfRequired => _polyfillIfRequired;
 
-  bool get secureCookie => _secureCookie;
+  bool? get secureCookie => _secureCookie;
 
-  bool get loadIntegration => _loadIntegration;
+  bool? get loadIntegration => _loadIntegration;
 
   SessionOpts? get sessions => _sessions;
 
@@ -171,16 +163,14 @@ class WebConfig {
 
   String? get polyfillURL => _polyfillURL;
 
-  bool get useGlobalIntegrationsConfigInEvents =>
+  bool? get useGlobalIntegrationsConfigInEvents =>
       _useGlobalIntegrationsConfigInEvents;
 
-  bool get bufferDataPlaneEventsUntilReady => _bufferDataPlaneEventsUntilReady;
+  bool? get bufferDataPlaneEventsUntilReady => _bufferDataPlaneEventsUntilReady;
 
-  int get dataPlaneEventsBufferTimeout => _dataPlaneEventsBufferTimeout;
+  int? get dataPlaneEventsBufferTimeout => _dataPlaneEventsBufferTimeout;
 
   PreConsentOptions? get preConsent => _preConsent;
-
-  EventsTransportMode? get transportMode => _transportMode;
 
   ConsentManagementOptions? get consentManagement => _consentManagement;
 
@@ -188,7 +178,7 @@ class WebConfig {
 
   String? get externalAnonymousIdCookieName => _externalAnonymousIdCookieName;
 
-  bool get useServerSideCookies => _useServerSideCookies;
+  bool? get useServerSideCookies => _useServerSideCookies;
 
   String? get dataServiceEndpoint => _dataServiceEndpoint;
 

--- a/packages/plugins/rudder_plugin_interface/lib/src/models/rudder_web_config.dart
+++ b/packages/plugins/rudder_plugin_interface/lib/src/models/rudder_web_config.dart
@@ -1,4 +1,5 @@
 import '../constants.dart';
+import './web_config_interfaces/index.dart';
 
 class WebConfig {
   ///web default true
@@ -43,6 +44,20 @@ class WebConfig {
   /// @param sessionTimeoutInMillis (duration of inactivity of session in milliseconds)
   final int _sessionTimeoutInMillis;
 
+  /// @param pluginsSDKBaseURL (base url to fetch plugins from)
+  final String? _pluginsSDKBaseURL;
+
+  /// default false
+  final bool _lockIntegrationsVersion;
+
+  /// default false
+  final bool _lockPluginsVersion;
+
+  /// default false
+  final bool _polyfillIfRequired;
+
+  final StorageOpts? _storage;
+
   WebConfig(
       {loadIntegration = Constants.DEFAULT_LOAD_INTEGRATION,
       secureCookie = Constants.DEFAULT_SECURE_COOKIE,
@@ -58,7 +73,12 @@ class WebConfig {
       destSDKBaseURL = Constants.DEFAULT_DESTINATION_SDK_BASE_URL,
       autoSessionTracking = Constants.AUTO_SESSION_TRACKING,
       sessionTimeoutInMillis = Constants.DEFAULT_SESSION_TIMEOUT_WEB,
-      Map<String, bool>? cookieConsentManagers})
+      lockIntegrationsVersion = Constants.DEFAULT_LOCK_INTEGRATIONS_VERSION,
+      lockPluginsVersion = Constants.DEFAULT_LOCK_PLUGINS_VERSION,
+      polyfillIfRequired = Constants.DEFAULT_POLYFILL_IF_REQUIRED,
+      Map<String, bool>? cookieConsentManagers,
+      pluginsSDKBaseURL,
+      storage})
       : _loadIntegration = loadIntegration,
         _secureCookie = secureCookie,
         _useBeacon = useBeacon,
@@ -72,11 +92,22 @@ class WebConfig {
         _destSDKBaseURL = destSDKBaseURL,
         _autoSessionTracking = autoSessionTracking,
         _sessionTimeoutInMillis = sessionTimeoutInMillis,
-        _cookieConsentManagers = cookieConsentManagers;
+        _cookieConsentManagers = cookieConsentManagers,
+        _pluginsSDKBaseURL = pluginsSDKBaseURL,
+        _lockIntegrationsVersion = lockIntegrationsVersion,
+        _lockPluginsVersion = lockPluginsVersion,
+        _polyfillIfRequired = polyfillIfRequired,
+        _storage = storage;
 
   String get destSDKBaseURL => _destSDKBaseURL;
 
   bool get useBeacon => _useBeacon;
+
+  bool get lockIntegrationsVersion => _lockIntegrationsVersion;
+
+  bool get lockPluginsVersion => _lockPluginsVersion;
+
+  bool get polyfillIfRequired => _polyfillIfRequired;
 
   bool get secureCookie => _secureCookie;
 
@@ -101,4 +132,8 @@ class WebConfig {
   bool get autoSessionTracking => _autoSessionTracking;
 
   int get sessionTimeoutInMillis => _sessionTimeoutInMillis;
+
+  String? get pluginsSDKBaseURL => _pluginsSDKBaseURL;
+
+  StorageOpts? get storage => _storage;
 }

--- a/packages/plugins/rudder_plugin_interface/lib/src/models/rudder_web_config.dart
+++ b/packages/plugins/rudder_plugin_interface/lib/src/models/rudder_web_config.dart
@@ -8,41 +8,16 @@ class WebConfig {
   ///web default false
   final bool _secureCookie;
 
-  /// web default 3_60_000
-  final int _maxRetryDelay;
-
-  ///web default 1_000
-  final int _minRetryDelay;
-
-  ///web back off factor default 2
-  final int _backoffFactor;
-
-  /// web default 10
-  final int _maxAttempts;
-
-  /// web default 100
-  final int _maxItems;
+  final QueueOpts? _queueOptions;
 
   ///web default false
   final bool _useBeacon;
 
-  ///utilised only if _useBeacon is true
-  final int _maxBeaconItems;
+  final BeaconQueueOpts? _beaconQueueOptions;
 
-  ///utilised only if _useBeacon is true
-  final int _beaconFlushQueueInterval;
+  final String? _destSDKBaseURL;
 
-  ///web default https://cdn.rudderlabs.com/v1.1/js-integrations
-  final String _destSDKBaseURL;
-
-  ///cookie consent managers, e.g ("oneTrust", true), default empty
-  final Map<String, bool>? _cookieConsentManagers;
-
-  /// @param autoSessionTracking whether to track session automatically
-  final bool _autoSessionTracking;
-
-  /// @param sessionTimeoutInMillis (duration of inactivity of session in milliseconds)
-  final int _sessionTimeoutInMillis;
+  final SessionOpts? _sessions;
 
   /// @param pluginsSDKBaseURL (base url to fetch plugins from)
   final String? _pluginsSDKBaseURL;
@@ -58,48 +33,109 @@ class WebConfig {
 
   final StorageOpts? _storage;
 
+  final DestinationsQueueOpts? _destinationsQueueOpts;
+
+  final AnonymousIdOptions? _anonymousIdOptions;
+
+  final OnLoadedCallback? _onLoaded;
+
+  final UaChTrackLevel? _uaChTrackLevel;
+
+  final bool? _sendAdblockPage;
+
+  final ApiOptions? _sendAdblockPageOptions;
+
+  final List<PluginName>? _plugins;
+
+  final String? _polyfillURL;
+
+  final bool _useGlobalIntegrationsConfigInEvents;
+
+  final bool _bufferDataPlaneEventsUntilReady;
+
+  final int _dataPlaneEventsBufferTimeout;
+
+  final PreConsentOptions? _preConsent;
+
+  final EventsTransportMode? _transportMode;
+
+  final ConsentManagementOptions? _consentManagement;
+
+  final bool? _sameDomainCookiesOnly;
+
+  final String? _externalAnonymousIdCookieName;
+
+  final bool _useServerSideCookies;
+
+  final String? _dataServiceEndpoint;
+
   WebConfig(
       {loadIntegration = Constants.DEFAULT_LOAD_INTEGRATION,
       secureCookie = Constants.DEFAULT_SECURE_COOKIE,
       useBeacon = Constants.DEFAULT_USE_BEACON,
-      maxRetryDelay = Constants.DEFAULT_MAX_RETRY_DELAY,
-      minRetryDelay = Constants.DEFAULT_MIN_RETRY_DELAY,
-      backoffFactor = Constants.DEFAULT_BACK_OFF_FACTOR,
-      maxAttempts = Constants.DEFAULT_MAX_ATTEMPTS,
-      maxItems = Constants.DEFAULT_MAX_ITEMS,
-      maxBeaconItems = Constants.DEFAULT_BEACON_MAX_ITEMS,
-      int beaconFlushQueueInterval =
-          Constants.DEFAULT_BEACON_FLUSH_QUEUE_INTERVAL,
-      destSDKBaseURL = Constants.DEFAULT_DESTINATION_SDK_BASE_URL,
-      autoSessionTracking = Constants.AUTO_SESSION_TRACKING,
-      sessionTimeoutInMillis = Constants.DEFAULT_SESSION_TIMEOUT_WEB,
       lockIntegrationsVersion = Constants.DEFAULT_LOCK_INTEGRATIONS_VERSION,
       lockPluginsVersion = Constants.DEFAULT_LOCK_PLUGINS_VERSION,
       polyfillIfRequired = Constants.DEFAULT_POLYFILL_IF_REQUIRED,
-      Map<String, bool>? cookieConsentManagers,
+      uaChTrackLevel = Constants.DEFAULT_UACH_TRACK_LEVEL,
+      useGlobalIntegrationsConfigInEvents =
+          Constants.DEFAULT_USE_GLOBAL_INTEGRATIONS_CONFIG_IN_EVENTS,
+      bufferDataPlaneEventsUntilReady =
+          Constants.DEFAULT_BUFFER_DATA_PLANE_EVENTS_UNTIL_READY,
+      dataPlaneEventsBufferTimeout =
+          Constants.DEFAULT_DATA_PLANE_EVENTS_BUFFER_TIMEOUT,
+      useServerSideCookies = Constants.DEFAULT_USE_SERVER_SIDE_COOKIES,
+      destSDKBaseURL,
       pluginsSDKBaseURL,
-      storage})
+      storage,
+      destinationsQueueOpts,
+      anonymousIdOptions,
+      onLoaded,
+      sendAdblockPage,
+      sendAdblockPageOptions,
+      plugins,
+      polyfillURL,
+      preConsent,
+      transportMode,
+      consentManagement,
+      sameDomainCookiesOnly,
+      externalAnonymousIdCookieName,
+      dataServiceEndpoint,
+      queueOptions,
+      beaconQueueOptions,
+      sessions})
       : _loadIntegration = loadIntegration,
         _secureCookie = secureCookie,
         _useBeacon = useBeacon,
-        _maxRetryDelay = maxRetryDelay,
-        _minRetryDelay = minRetryDelay,
-        _backoffFactor = backoffFactor,
-        _maxAttempts = maxAttempts,
-        _maxItems = maxItems,
-        _maxBeaconItems = maxBeaconItems,
-        _beaconFlushQueueInterval = beaconFlushQueueInterval,
         _destSDKBaseURL = destSDKBaseURL,
-        _autoSessionTracking = autoSessionTracking,
-        _sessionTimeoutInMillis = sessionTimeoutInMillis,
-        _cookieConsentManagers = cookieConsentManagers,
+        _sessions = sessions,
         _pluginsSDKBaseURL = pluginsSDKBaseURL,
         _lockIntegrationsVersion = lockIntegrationsVersion,
         _lockPluginsVersion = lockPluginsVersion,
         _polyfillIfRequired = polyfillIfRequired,
-        _storage = storage;
+        _storage = storage,
+        _destinationsQueueOpts = destinationsQueueOpts,
+        _anonymousIdOptions = anonymousIdOptions,
+        _onLoaded = onLoaded,
+        _uaChTrackLevel = uaChTrackLevel,
+        _sendAdblockPage = sendAdblockPage,
+        _sendAdblockPageOptions = sendAdblockPageOptions,
+        _plugins = plugins,
+        _polyfillURL = polyfillURL,
+        _useGlobalIntegrationsConfigInEvents =
+            useGlobalIntegrationsConfigInEvents,
+        _bufferDataPlaneEventsUntilReady = bufferDataPlaneEventsUntilReady,
+        _dataPlaneEventsBufferTimeout = dataPlaneEventsBufferTimeout,
+        _preConsent = preConsent,
+        _transportMode = transportMode,
+        _consentManagement = consentManagement,
+        _sameDomainCookiesOnly = sameDomainCookiesOnly,
+        _externalAnonymousIdCookieName = externalAnonymousIdCookieName,
+        _useServerSideCookies = useServerSideCookies,
+        _dataServiceEndpoint = dataServiceEndpoint,
+        _queueOptions = queueOptions,
+        _beaconQueueOptions = beaconQueueOptions;
 
-  String get destSDKBaseURL => _destSDKBaseURL;
+  String? get destSDKBaseURL => _destSDKBaseURL;
 
   bool get useBeacon => _useBeacon;
 
@@ -113,27 +149,50 @@ class WebConfig {
 
   bool get loadIntegration => _loadIntegration;
 
-  Map<String, bool>? get cookieConsentManagers => _cookieConsentManagers;
-
-  int get beaconFlushQueueInterval => _beaconFlushQueueInterval;
-
-  int get maxBeaconItems => _maxBeaconItems;
-
-  int get maxItems => _maxItems;
-
-  int get maxAttempts => _maxAttempts;
-
-  int get backoffFactor => _backoffFactor;
-
-  int get minRetryDelay => _minRetryDelay;
-
-  int get maxRetryDelay => _maxRetryDelay;
-
-  bool get autoSessionTracking => _autoSessionTracking;
-
-  int get sessionTimeoutInMillis => _sessionTimeoutInMillis;
+  SessionOpts? get sessions => _sessions;
 
   String? get pluginsSDKBaseURL => _pluginsSDKBaseURL;
 
   StorageOpts? get storage => _storage;
+
+  DestinationsQueueOpts? get destinationsQueueOpts => _destinationsQueueOpts;
+
+  AnonymousIdOptions? get anonymousIdOptions => _anonymousIdOptions;
+
+  OnLoadedCallback? get onLoaded => _onLoaded;
+
+  UaChTrackLevel? get uaChTrackLevel => _uaChTrackLevel;
+
+  bool? get sendAdblockPage => _sendAdblockPage;
+
+  ApiOptions? get sendAdblockPageOptions => _sendAdblockPageOptions;
+
+  List<PluginName>? get plugins => _plugins;
+
+  String? get polyfillURL => _polyfillURL;
+
+  bool get useGlobalIntegrationsConfigInEvents =>
+      _useGlobalIntegrationsConfigInEvents;
+
+  bool get bufferDataPlaneEventsUntilReady => _bufferDataPlaneEventsUntilReady;
+
+  int get dataPlaneEventsBufferTimeout => _dataPlaneEventsBufferTimeout;
+
+  PreConsentOptions? get preConsent => _preConsent;
+
+  EventsTransportMode? get transportMode => _transportMode;
+
+  ConsentManagementOptions? get consentManagement => _consentManagement;
+
+  bool? get sameDomainCookiesOnly => _sameDomainCookiesOnly;
+
+  String? get externalAnonymousIdCookieName => _externalAnonymousIdCookieName;
+
+  bool get useServerSideCookies => _useServerSideCookies;
+
+  String? get dataServiceEndpoint => _dataServiceEndpoint;
+
+  QueueOpts? get queueOptions => _queueOptions;
+
+  BeaconQueueOpts? get beaconQueueOptions => _beaconQueueOptions;
 }

--- a/packages/plugins/rudder_plugin_interface/lib/src/models/web_config_interfaces/anonymous_id_opts.dart
+++ b/packages/plugins/rudder_plugin_interface/lib/src/models/web_config_interfaces/anonymous_id_opts.dart
@@ -1,0 +1,31 @@
+class AutoCapture {
+  final bool? enabled;
+  final String? source;
+
+  AutoCapture({
+    this.enabled,
+    this.source,
+  });
+
+  // Method to convert AutoCapture object to a Map<String, dynamic>
+  Map<String, dynamic> toMap() {
+    return {
+      'enabled': enabled,
+      'source': source,
+    };
+  }
+}
+
+class AnonymousIdOptions {
+  final AutoCapture? autoCapture;
+
+  AnonymousIdOptions({this.autoCapture});
+
+  // Method to convert AnonymousIdOptions object to a Map<String, dynamic>
+  Map<String, dynamic> toMap() {
+    return {
+      'autoCapture':
+          autoCapture?.toMap(), // Convert autoCapture to a map if not null
+    };
+  }
+}

--- a/packages/plugins/rudder_plugin_interface/lib/src/models/web_config_interfaces/api_opts.dart
+++ b/packages/plugins/rudder_plugin_interface/lib/src/models/web_config_interfaces/api_opts.dart
@@ -1,0 +1,80 @@
+class ApiObject {
+  final Map<String, dynamic> properties;
+
+  ApiObject({required this.properties});
+
+  // Method to convert ApiObject to a Map<String, dynamic>
+  Map<String, dynamic> toMap() {
+    return properties;
+  }
+}
+
+class DestinationIntgConfig {
+  final bool? flag;
+  final ApiObject? apiObject;
+
+  DestinationIntgConfig({this.flag, this.apiObject});
+
+  // Method to convert DestinationIntgConfig to a Map<String, dynamic>
+  Map<String, dynamic> toMap() {
+    if (flag != null) {
+      return {'flag': flag};
+    } else if (apiObject != null) {
+      return {'apiObject': apiObject!.toMap()};
+    } else {
+      return {};
+    }
+  }
+}
+
+class IntegrationOpts {
+  final bool? all;
+  final Map<String, DestinationIntgConfig>? dynamicConfigs;
+
+  IntegrationOpts({this.all, this.dynamicConfigs});
+
+  // Method to convert IntegrationOpts to a Map<String, dynamic>
+  Map<String, dynamic> toMap() {
+    final map = <String, dynamic>{
+      'All': all,
+    };
+
+    // Add dynamic keys from dynamicConfigs
+    if (dynamicConfigs != null) {
+      map.addAll(
+          dynamicConfigs!.map((key, value) => MapEntry(key, value.toMap())));
+    }
+
+    return map;
+  }
+}
+
+class ApiOptions {
+  final IntegrationOpts? integrations;
+  final String? anonymousId;
+  final String? originalTimestamp;
+  final Map<String, dynamic>? additionalProperties;
+
+  ApiOptions({
+    this.integrations,
+    this.anonymousId,
+    this.originalTimestamp,
+    this.additionalProperties,
+  });
+
+  // Method to convert ApiOptions to a Map<String, dynamic>
+  Map<String, dynamic> toMap() {
+    final map = <String, dynamic>{
+      'integrations': integrations?.toMap(),
+      'anonymousId': anonymousId,
+      'originalTimestamp': originalTimestamp,
+    };
+
+    // Add dynamic additional properties
+    if (additionalProperties != null) {
+      map.addAll(additionalProperties!);
+    }
+
+    return map;
+  }
+}

--- a/packages/plugins/rudder_plugin_interface/lib/src/models/web_config_interfaces/beacon_queue_opts.dart
+++ b/packages/plugins/rudder_plugin_interface/lib/src/models/web_config_interfaces/beacon_queue_opts.dart
@@ -1,0 +1,14 @@
+class BeaconQueueOpts {
+  final int? maxItems;
+  final int? flushQueueInterval;
+
+  BeaconQueueOpts({this.maxItems, this.flushQueueInterval});
+
+  // Method to convert the BeaconQueueOpts object to a Map<String, dynamic>
+  Map<String, dynamic> toMap() {
+    return {
+      'maxItems': maxItems,
+      'flushQueueInterval': flushQueueInterval,
+    };
+  }
+}

--- a/packages/plugins/rudder_plugin_interface/lib/src/models/web_config_interfaces/consent_opts.dart
+++ b/packages/plugins/rudder_plugin_interface/lib/src/models/web_config_interfaces/consent_opts.dart
@@ -1,0 +1,84 @@
+enum DeliveryType {
+  immediate,
+  buffer,
+}
+
+enum StorageStrategy {
+  none,
+  session,
+  anonymousId,
+}
+
+enum ConsentManagementProvider {
+  oneTrust,
+  ketch,
+  custom,
+}
+
+class PreConsentStorageOptions {
+  final StorageStrategy strategy;
+
+  PreConsentStorageOptions({required this.strategy});
+
+  Map<String, dynamic> toMap() {
+    return {
+      'strategy': strategy.name, // Convert enum to string
+    };
+  }
+}
+
+class PreConsentEventsOptions {
+  final DeliveryType delivery;
+
+  PreConsentEventsOptions({required this.delivery});
+
+  Map<String, dynamic> toMap() {
+    return {
+      'delivery': delivery.name, // Convert enum to string
+    };
+  }
+}
+
+class PreConsentOptions {
+  final bool enabled;
+  final PreConsentStorageOptions? storage;
+  final PreConsentEventsOptions? events;
+
+  PreConsentOptions({
+    required this.enabled,
+    this.storage,
+    this.events,
+  });
+
+  Map<String, dynamic> toMap() {
+    return {
+      'enabled': enabled,
+      'storage': storage?.toMap(),
+      'events': events?.toMap(),
+    };
+  }
+}
+
+class ConsentManagementOptions {
+  final bool? enabled;
+  final ConsentManagementProvider? provider;
+  final List<String>? allowedConsentIds;
+  final List<String>? deniedConsentIds;
+
+  ConsentManagementOptions({
+    this.enabled,
+    this.provider,
+    this.allowedConsentIds,
+    this.deniedConsentIds,
+  });
+
+  // Convert ConsentManagementOptions to a Map<String, dynamic>
+  Map<String, dynamic> toMap() {
+    return {
+      'enabled': enabled,
+      'provider': provider?.name, // Convert enum to string
+      'allowedConsentIds': allowedConsentIds,
+      'deniedConsentIds': deniedConsentIds,
+    };
+  }
+}

--- a/packages/plugins/rudder_plugin_interface/lib/src/models/web_config_interfaces/destinations_queue_opts.dart
+++ b/packages/plugins/rudder_plugin_interface/lib/src/models/web_config_interfaces/destinations_queue_opts.dart
@@ -1,0 +1,12 @@
+class DestinationsQueueOpts {
+  final int? maxItems;
+
+  DestinationsQueueOpts({this.maxItems});
+
+  // Method to convert the DestinationsQueueOpts object to a Map<String, dynamic>
+  Map<String, dynamic> toMap() {
+    return {
+      'maxItems': maxItems,
+    };
+  }
+}

--- a/packages/plugins/rudder_plugin_interface/lib/src/models/web_config_interfaces/index.dart
+++ b/packages/plugins/rudder_plugin_interface/lib/src/models/web_config_interfaces/index.dart
@@ -1,0 +1,9 @@
+export 'anonymous_id_opts.dart';
+export 'api_opts.dart';
+export 'beacon_queue_opts.dart';
+export 'consent_opts.dart';
+export 'destinations_queue_opts.dart';
+export 'queue_opts.dart';
+export 'session_opts.dart';
+export 'storage_opts.dart';
+export 'load_opts.dart';

--- a/packages/plugins/rudder_plugin_interface/lib/src/models/web_config_interfaces/load_opts.dart
+++ b/packages/plugins/rudder_plugin_interface/lib/src/models/web_config_interfaces/load_opts.dart
@@ -1,7 +1,5 @@
 typedef OnLoadedCallback = void Function(dynamic analytics);
 
-enum EventsTransportMode { xhr, beacon }
-
 enum PluginName {
   BeaconQueue,
   CustomConsentManager,

--- a/packages/plugins/rudder_plugin_interface/lib/src/models/web_config_interfaces/load_opts.dart
+++ b/packages/plugins/rudder_plugin_interface/lib/src/models/web_config_interfaces/load_opts.dart
@@ -1,0 +1,39 @@
+typedef OnLoadedCallback = void Function(dynamic analytics);
+
+enum EventsTransportMode { xhr, beacon }
+
+enum PluginName {
+  BeaconQueue,
+  CustomConsentManager,
+  DeviceModeDestinations,
+  DeviceModeTransformation,
+  ErrorReporting,
+  ExternalAnonymousId,
+  GoogleLinker,
+  KetchConsentManager,
+  NativeDestinationQueue,
+  OneTrustConsentManager,
+  StorageEncryption,
+  StorageEncryptionLegacy,
+  StorageMigrator,
+  XhrQueue,
+}
+
+enum UaChTrackLevel {
+  none,
+  defaultLevel, // Renaming it to avoid conflicts with Dart's `default` keyword
+  full,
+}
+
+extension UaChTrackLevelExtension on UaChTrackLevel {
+  String get value {
+    switch (this) {
+      case UaChTrackLevel.none:
+        return 'none';
+      case UaChTrackLevel.defaultLevel:
+        return 'default';
+      case UaChTrackLevel.full:
+        return 'full';
+    }
+  }
+}

--- a/packages/plugins/rudder_plugin_interface/lib/src/models/web_config_interfaces/load_opts.dart
+++ b/packages/plugins/rudder_plugin_interface/lib/src/models/web_config_interfaces/load_opts.dart
@@ -20,20 +20,11 @@ enum PluginName {
 }
 
 enum UaChTrackLevel {
-  none,
-  defaultLevel, // Renaming it to avoid conflicts with Dart's `default` keyword
-  full,
-}
+  none('none'),
+  defaultLevel('default'),
+  full('full');
 
-extension UaChTrackLevelExtension on UaChTrackLevel {
-  String get value {
-    switch (this) {
-      case UaChTrackLevel.none:
-        return 'none';
-      case UaChTrackLevel.defaultLevel:
-        return 'default';
-      case UaChTrackLevel.full:
-        return 'full';
-    }
-  }
+  final String value;
+
+  const UaChTrackLevel(this.value);
 }

--- a/packages/plugins/rudder_plugin_interface/lib/src/models/web_config_interfaces/queue_opts.dart
+++ b/packages/plugins/rudder_plugin_interface/lib/src/models/web_config_interfaces/queue_opts.dart
@@ -1,0 +1,60 @@
+class BatchOpts {
+  final bool enabled;
+  final int? maxItems;
+  final int? maxSize;
+  final int? flushInterval;
+
+  BatchOpts({
+    required this.enabled,
+    this.maxItems,
+    this.maxSize,
+    this.flushInterval,
+  });
+
+  // Method to convert the BatchOpts object to a Map<String, dynamic>
+  Map<String, dynamic> toMap() {
+    return {
+      'enabled': enabled,
+      'maxItems': maxItems,
+      'maxSize': maxSize,
+      'flushInterval': flushInterval,
+    };
+  }
+}
+
+class QueueOpts {
+  final int? maxRetryDelay;
+  final int? minRetryDelay;
+  final double? backoffFactor;
+  final double? backoffJitter;
+  final int? maxAttempts;
+  final int? maxItems;
+  final BatchOpts? batch;
+  final double? timerScaleFactor;
+
+  QueueOpts({
+    this.maxRetryDelay,
+    this.minRetryDelay,
+    this.backoffFactor,
+    this.backoffJitter,
+    this.maxAttempts,
+    this.maxItems,
+    this.batch,
+    this.timerScaleFactor,
+  });
+
+  // Method to convert QueueOpts object to a Map<String, dynamic>
+  Map<String, dynamic> toMap() {
+    return {
+      'maxRetryDelay': maxRetryDelay,
+      'minRetryDelay': minRetryDelay,
+      'backoffFactor': backoffFactor,
+      'backoffJitter': backoffJitter,
+      'maxAttempts': maxAttempts,
+      'maxItems': maxItems,
+      'batch':
+          batch?.toMap(), // Convert the batch object to a map if it's not null
+      'timerScaleFactor': timerScaleFactor,
+    };
+  }
+}

--- a/packages/plugins/rudder_plugin_interface/lib/src/models/web_config_interfaces/session_opts.dart
+++ b/packages/plugins/rudder_plugin_interface/lib/src/models/web_config_interfaces/session_opts.dart
@@ -1,0 +1,14 @@
+class SessionOpts {
+  final bool? autoTrack;
+  final int? timeout;
+
+  SessionOpts({this.autoTrack, this.timeout});
+
+  // Method to convert the SessionOpts object to a Map<String, dynamic>
+  Map<String, dynamic> toMap() {
+    return {
+      'autoTrack': autoTrack,
+      'timeout': timeout,
+    };
+  }
+}

--- a/packages/plugins/rudder_plugin_interface/lib/src/models/web_config_interfaces/storage_opts.dart
+++ b/packages/plugins/rudder_plugin_interface/lib/src/models/web_config_interfaces/storage_opts.dart
@@ -1,0 +1,112 @@
+// Define the StorageType enum
+enum StorageType {
+  cookieStorage,
+  localStorage,
+  memoryStorage,
+  sessionStorage,
+  none,
+}
+
+enum UserSessionKey {
+  userId,
+  userTraits,
+  anonymousId,
+  groupId,
+  groupTraits,
+  initialReferrer,
+  initialReferringDomain,
+  sessionInfo,
+  authToken,
+}
+
+enum StorageEncryptionVersion {
+  legacy,
+  v3,
+}
+
+// Define the LoadOptionStorageEntry class
+class LoadOptionStorageEntry {
+  final StorageType type;
+
+  LoadOptionStorageEntry({required this.type});
+
+  // Method to convert the LoadOptionStorageEntry object to a Map<String, dynamic>
+  Map<String, dynamic> toMap() {
+    return {
+      'type': type.toString().split('.').last,
+    };
+  }
+}
+
+// Define the StorageEncryption class
+class StorageEncryption {
+  final StorageEncryptionVersion version;
+
+  StorageEncryption({required this.version});
+
+  // Method to convert the StorageEncryption object to a Map<String, dynamic>
+  Map<String, dynamic> toMap() {
+    return {
+      'version': version.toString().split('.').last,
+    };
+  }
+}
+
+class CookieOptions {
+  final int? maxage;
+  final DateTime? expires;
+  final String? path;
+  final String? domain;
+  final String? samesite;
+  final bool? secure;
+
+  CookieOptions({
+    this.maxage,
+    this.expires,
+    this.path,
+    this.domain,
+    this.samesite,
+    this.secure,
+  });
+
+  // Method to convert the CookieOptions object to a Map<String, dynamic>
+  Map<String, dynamic> toMap() {
+    return {
+      'maxage': maxage,
+      'expires': expires?.toIso8601String(),
+      'path': path,
+      'domain': domain,
+      'samesite': samesite,
+      'secure': secure,
+    };
+  }
+}
+
+// Define the StorageOpts class
+class StorageOpts {
+  final StorageEncryption? encryption;
+  final bool? migrate;
+  final StorageType? type;
+  final CookieOptions? cookie;
+  final Map<UserSessionKey, LoadOptionStorageEntry>? entries;
+
+  StorageOpts({
+    this.encryption,
+    this.migrate,
+    this.type,
+    this.cookie,
+    this.entries,
+  });
+
+  // Method to convert the StorageOpts object to a Map<String, dynamic>
+  Map<String, dynamic> toMap() {
+    return {
+      'encryption': encryption?.toMap(),
+      'migrate': migrate,
+      'type': type?.toString().split('.').last, // Convert enum to string
+      'cookie': cookie?.toMap(),
+      'entries': entries?.map((key, value) =>
+          MapEntry(key.toString().split('.').last, value.toMap())),
+    };
+  }
+}

--- a/packages/plugins/rudder_plugin_interface/lib/src/models/web_config_interfaces/storage_opts.dart
+++ b/packages/plugins/rudder_plugin_interface/lib/src/models/web_config_interfaces/storage_opts.dart
@@ -24,13 +24,13 @@ enum StorageEncryptionVersion {
   v3,
 }
 
-// Define the LoadOptionStorageEntry class
-class LoadOptionStorageEntry {
+// Define the StorageEntry class
+class StorageEntry {
   final StorageType type;
 
-  LoadOptionStorageEntry({required this.type});
+  StorageEntry({required this.type});
 
-  // Method to convert the LoadOptionStorageEntry object to a Map<String, dynamic>
+  // Method to convert the StorageEntry object to a Map<String, dynamic>
   Map<String, dynamic> toMap() {
     return {
       'type': type.toString().split('.').last,
@@ -88,7 +88,7 @@ class StorageOpts {
   final bool? migrate;
   final StorageType? type;
   final CookieOptions? cookie;
-  final Map<UserSessionKey, LoadOptionStorageEntry>? entries;
+  final Map<UserSessionKey, StorageEntry>? entries;
 
   StorageOpts({
     this.encryption,

--- a/packages/plugins/rudder_plugin_interface/pubspec.lock
+++ b/packages/plugins/rudder_plugin_interface/pubspec.lock
@@ -207,26 +207,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -255,18 +255,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.15.0"
   package_config:
     dependency: transitive
     description:
@@ -380,10 +380,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:
@@ -412,10 +412,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.5"
   watcher:
     dependency: transitive
     description:
@@ -441,5 +441,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=3.2.0-0 <4.0.0"
-  flutter: ">=2.0.0"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/packages/plugins/rudder_plugin_interface/test/src/models/rudder_config_test.dart
+++ b/packages/plugins/rudder_plugin_interface/test/src/models/rudder_config_test.dart
@@ -11,16 +11,47 @@ void main() {
     final MobileConfig mobileConfig = MobileConfig(
         dbCountThreshold: 400, sleepTimeOut: 5000, configRefreshInterval: 20);
     final WebConfig webConfig = WebConfig(
-      storage: StorageOpts(type: StorageType.localStorage, entries: {
-        UserSessionKey.anonymousId:
-            StorageEntry(type: StorageType.cookieStorage)
-      }),
+      storage: StorageOpts(
+          encryption: StorageEncryption(version: StorageEncryptionVersion.v3),
+          migrate: true,
+          type: StorageType.sessionStorage,
+          cookie: CookieOptions(
+            maxage: 1000,
+            path: "/",
+            domain: "example.com",
+            samesite: "Lax",
+            secure: true,
+          ),
+          entries: {
+            UserSessionKey.anonymousId:
+                StorageEntry(type: StorageType.cookieStorage),
+            UserSessionKey.userId:
+                StorageEntry(type: StorageType.cookieStorage),
+            UserSessionKey.userTraits:
+                StorageEntry(type: StorageType.localStorage),
+            UserSessionKey.sessionInfo:
+                StorageEntry(type: StorageType.memoryStorage),
+            UserSessionKey.groupId: StorageEntry(type: StorageType.none),
+            UserSessionKey.groupTraits: StorageEntry(type: StorageType.none),
+            UserSessionKey.initialReferrer:
+                StorageEntry(type: StorageType.cookieStorage),
+            UserSessionKey.initialReferringDomain:
+                StorageEntry(type: StorageType.cookieStorage),
+          }),
       lockIntegrationsVersion: true,
       lockPluginsVersion: true,
       destSDKBaseURL: "https://api.com",
       pluginsSDKBaseURL: "https://api.com/plugins/",
       queueOptions: QueueOpts(
-          maxRetryDelay: 60000, minRetryDelay: 1000, backoffFactor: 2),
+          maxRetryDelay: 5 * 60 * 1000,
+          minRetryDelay: 1000,
+          backoffFactor: 2,
+          backoffJitter: 0.1,
+          maxAttempts: 5,
+          maxItems: 10,
+          batch: BatchOpts(
+              enabled: true, maxItems: 5, maxSize: 1000, flushInterval: 1000),
+          timerScaleFactor: 1.5),
       useBeacon: true,
       beaconQueueOptions:
           BeaconQueueOpts(maxItems: 2, flushQueueInterval: 5000),
@@ -48,10 +79,14 @@ void main() {
       preConsent: PreConsentOptions(
         enabled: true,
         events: PreConsentEventsOptions(delivery: DeliveryType.immediate),
+        storage:
+            PreConsentStorageOptions(strategy: StorageStrategy.anonymousId),
       ),
       consentManagement: ConsentManagementOptions(
         enabled: true,
         provider: ConsentManagementProvider.oneTrust,
+        allowedConsentIds: ["consent1", "consent2"],
+        deniedConsentIds: ["consent3", "consent4"],
       ),
       polyfillURL: "https://dummy-polyfill.com",
       sameDomainCookiesOnly: false,

--- a/packages/plugins/rudder_plugin_interface/test/src/models/rudder_config_test.dart
+++ b/packages/plugins/rudder_plugin_interface/test/src/models/rudder_config_test.dart
@@ -11,10 +11,23 @@ void main() {
     final MobileConfig mobileConfig = MobileConfig(
         dbCountThreshold: 400, sleepTimeOut: 5000, configRefreshInterval: 20);
     final WebConfig webConfig = WebConfig(
-        maxAttempts: 12,
-        maxRetryDelay: 1300,
-        destSDKBaseURL: "https://api.com",
-        cookieConsentManagers: {"oneTrust": false});
+      storage: StorageOpts(type: StorageType.localStorage, entries: {
+        UserSessionKey.anonymousId:
+            LoadOptionStorageEntry(type: StorageType.cookieStorage)
+      }),
+      lockIntegrationsVersion: true,
+      lockPluginsVersion: true,
+      destSDKBaseURL: "https://api.com",
+      pluginsSDKBaseURL: "https://api.com/plugins/",
+      queueOptions: QueueOpts(
+          maxRetryDelay: 60000, minRetryDelay: 1000, backoffFactor: 2),
+      useBeacon: true,
+      beaconQueueOptions:
+          BeaconQueueOpts(maxItems: 2, flushQueueInterval: 5000),
+      sessions: SessionOpts(autoTrack: true, timeout: 2 * 60 * 1000),
+      uaChTrackLevel: UaChTrackLevel.defaultLevel,
+      plugins: [PluginName.BeaconQueue, PluginName.DeviceModeDestinations],
+    );
 
     final List<RudderIntegration> factories = [
       create(() {}, "1"),
@@ -46,12 +59,21 @@ void main() {
     expect(mobileMap["sleepTimeOut"], equals(mobileConfig.sleepTimeOut));
 
     expect(webMap["configUrl"], equals("$configUrl/"));
+    expect(webMap["storage"], isA<Map>());
+    expect(webMap["storage"], equals(webConfig.storage?.toMap()));
     expect(webMap["queueOptions"], isA<Map>());
-    expect(webMap["destSDKBaseURL"], webConfig.destSDKBaseURL);
-
-    final Map<String, dynamic> queueOpts = webMap["queueOptions"];
-    expect(queueOpts["maxRetryDelay"], webConfig.maxRetryDelay.toString());
-    expect(queueOpts["maxAttempts"], webConfig.maxAttempts.toString());
+    expect(webMap["queueOptions"], equals(webConfig.queueOptions?.toMap()));
+    expect(webMap["destSDKBaseURL"], equals(webConfig.destSDKBaseURL));
+    expect(webMap["pluginsSDKBaseURL"], equals(webConfig.pluginsSDKBaseURL));
+    expect(webMap["lockIntegrationsVersion"],
+        equals(webConfig.lockIntegrationsVersion));
+    expect(webMap["lockPluginsVersion"], equals(webConfig.lockPluginsVersion));
+    expect(webMap["useBeacon"], equals(webConfig.useBeacon));
+    expect(webMap["beaconQueueOptions"],
+        equals(webConfig.beaconQueueOptions?.toMap()));
+    expect(webMap["sessions"], equals(webConfig.sessions?.toMap()));
+    expect(webMap["uaChTrackLevel"], equals(webConfig.uaChTrackLevel?.value));
+    expect(webMap["plugins"], equals(webConfig.plugins));
   });
 
   test('data residency value is properly set', () {

--- a/packages/plugins/rudder_plugin_interface/test/src/models/rudder_config_test.dart
+++ b/packages/plugins/rudder_plugin_interface/test/src/models/rudder_config_test.dart
@@ -13,7 +13,7 @@ void main() {
     final WebConfig webConfig = WebConfig(
       storage: StorageOpts(type: StorageType.localStorage, entries: {
         UserSessionKey.anonymousId:
-            LoadOptionStorageEntry(type: StorageType.cookieStorage)
+            StorageEntry(type: StorageType.cookieStorage)
       }),
       lockIntegrationsVersion: true,
       lockPluginsVersion: true,
@@ -27,6 +27,36 @@ void main() {
       sessions: SessionOpts(autoTrack: true, timeout: 2 * 60 * 1000),
       uaChTrackLevel: UaChTrackLevel.defaultLevel,
       plugins: [PluginName.BeaconQueue, PluginName.DeviceModeDestinations],
+      loadIntegration: true,
+      secureCookie: false,
+      polyfillIfRequired: true,
+      destinationsQueueOpts: DestinationsQueueOpts(maxItems: 10),
+      useGlobalIntegrationsConfigInEvents: true,
+      bufferDataPlaneEventsUntilReady: true,
+      dataPlaneEventsBufferTimeout: 1000,
+      useServerSideCookies: false,
+      anonymousIdOptions: AnonymousIdOptions(
+          autoCapture: AutoCapture(enabled: true, source: "source")),
+      onLoaded: (analytics) => {analytics.setAnonymousId("123")},
+      sendAdblockPage: true,
+      sendAdblockPageOptions: ApiOptions(
+        additionalProperties: {
+          "key1": "value1",
+          "key2": 12345,
+        },
+      ),
+      preConsent: PreConsentOptions(
+        enabled: true,
+        events: PreConsentEventsOptions(delivery: DeliveryType.immediate),
+      ),
+      consentManagement: ConsentManagementOptions(
+        enabled: true,
+        provider: ConsentManagementProvider.oneTrust,
+      ),
+      polyfillURL: "https://dummy-polyfill.com",
+      sameDomainCookiesOnly: false,
+      externalAnonymousIdCookieName: "external_anonymous_id",
+      dataServiceEndpoint: "https://data-service.com",
     );
 
     final List<RudderIntegration> factories = [
@@ -74,6 +104,35 @@ void main() {
     expect(webMap["sessions"], equals(webConfig.sessions?.toMap()));
     expect(webMap["uaChTrackLevel"], equals(webConfig.uaChTrackLevel?.value));
     expect(webMap["plugins"], equals(webConfig.plugins));
+    expect(webMap["loadIntegration"], equals(webConfig.loadIntegration));
+    expect(webMap["secureCookie"], equals(webConfig.secureCookie));
+    expect(webMap["polyfillIfRequired"], equals(webConfig.polyfillIfRequired));
+    expect(webMap["destinationsQueueOpts"],
+        equals(webConfig.destinationsQueueOpts?.toMap()));
+    expect(webMap["useGlobalIntegrationsConfigInEvents"],
+        equals(webConfig.useGlobalIntegrationsConfigInEvents));
+    expect(webMap["bufferDataPlaneEventsUntilReady"],
+        equals(webConfig.bufferDataPlaneEventsUntilReady));
+    expect(webMap["dataPlaneEventsBufferTimeout"],
+        equals(webConfig.dataPlaneEventsBufferTimeout));
+    expect(
+        webMap["useServerSideCookies"], equals(webConfig.useServerSideCookies));
+    expect(webMap["anonymousIdOptions"],
+        equals(webConfig.anonymousIdOptions?.toMap()));
+    expect(webMap["onLoaded"], isNotNull);
+    expect(webMap["sendAdblockPage"], equals(webConfig.sendAdblockPage));
+    expect(webMap["sendAdblockPageOptions"],
+        equals(webConfig.sendAdblockPageOptions?.toMap()));
+    expect(webMap["preConsent"], equals(webConfig.preConsent?.toMap()));
+    expect(webMap["consentManagement"],
+        equals(webConfig.consentManagement?.toMap()));
+    expect(webMap["polyfillURL"], equals(webConfig.polyfillURL));
+    expect(webMap["sameDomainCookiesOnly"],
+        equals(webConfig.sameDomainCookiesOnly));
+    expect(webMap["externalAnonymousIdCookieName"],
+        equals(webConfig.externalAnonymousIdCookieName));
+    expect(
+        webMap["dataServiceEndpoint"], equals(webConfig.dataServiceEndpoint));
   });
 
   test('data residency value is properly set', () {

--- a/packages/plugins/rudder_plugin_ios/pubspec.lock
+++ b/packages/plugins/rudder_plugin_ios/pubspec.lock
@@ -207,26 +207,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -255,18 +255,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.15.0"
   package_config:
     dependency: transitive
     description:
@@ -337,7 +337,7 @@ packages:
       path: "../rudder_plugin_interface"
       relative: true
     source: path
-    version: "2.8.0"
+    version: "2.9.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -387,10 +387,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:
@@ -419,10 +419,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.5"
   watcher:
     dependency: transitive
     description:
@@ -448,5 +448,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=3.2.0-0 <4.0.0"
-  flutter: ">=2.0.0"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/packages/plugins/rudder_plugin_web/pubspec.lock
+++ b/packages/plugins/rudder_plugin_web/pubspec.lock
@@ -220,26 +220,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -268,18 +268,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.15.0"
   package_config:
     dependency: transitive
     description:
@@ -350,7 +350,7 @@ packages:
       path: "../rudder_plugin_interface"
       relative: true
     source: path
-    version: "2.8.0"
+    version: "2.9.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -400,10 +400,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:
@@ -432,10 +432,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.5"
   watcher:
     dependency: transitive
     description:
@@ -461,5 +461,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.2.0-0 <4.0.0"
-  flutter: ">=2.0.0"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -343,18 +343,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.15.0"
   mime:
     dependency: transitive
     description:
@@ -481,91 +481,91 @@ packages:
       path: "packages/integrations/rudder_integration_adjust_flutter"
       relative: true
     source: path
-    version: "1.2.2"
+    version: "1.3.0"
   rudder_integration_amplitude_flutter:
     dependency: "direct main"
     description:
       path: "packages/integrations/rudder_integration_amplitude_flutter"
       relative: true
     source: path
-    version: "1.2.2"
+    version: "1.3.0"
   rudder_integration_appcenter_flutter:
     dependency: "direct main"
     description:
       path: "packages/integrations/rudder_integration_appcenter_flutter"
       relative: true
     source: path
-    version: "1.3.2"
+    version: "1.4.0"
   rudder_integration_appsflyer_flutter:
     dependency: "direct main"
     description:
       path: "packages/integrations/rudder_integration_appsflyer_flutter"
       relative: true
     source: path
-    version: "1.1.12"
+    version: "1.1.13"
   rudder_integration_braze_flutter:
     dependency: "direct main"
     description:
       path: "packages/integrations/rudder_integration_braze_flutter"
       relative: true
     source: path
-    version: "1.2.2"
+    version: "1.3.0"
   rudder_integration_firebase_flutter:
     dependency: "direct main"
     description:
       path: "packages/integrations/rudder_integration_firebase_flutter"
       relative: true
     source: path
-    version: "2.2.2"
+    version: "2.3.0"
   rudder_integration_kochava_flutter:
     dependency: "direct main"
     description:
       path: "packages/integrations/rudder_integration_kochava_flutter"
       relative: true
     source: path
-    version: "1.1.3"
+    version: "1.2.0"
   rudder_integration_leanplum_flutter:
     dependency: "direct main"
     description:
       path: "packages/integrations/rudder_integration_leanplum_flutter"
       relative: true
     source: path
-    version: "1.2.2"
+    version: "1.3.0"
   rudder_plugin_android:
     dependency: "direct overridden"
     description:
       path: "packages/plugins/rudder_plugin_android"
       relative: true
     source: path
-    version: "2.8.0"
+    version: "2.9.0"
   rudder_plugin_ios:
     dependency: "direct overridden"
     description:
       path: "packages/plugins/rudder_plugin_ios"
       relative: true
     source: path
-    version: "2.8.1"
+    version: "2.9.0"
   rudder_plugin_web:
     dependency: "direct overridden"
     description:
       path: "packages/plugins/rudder_plugin_web"
       relative: true
     source: path
-    version: "2.7.0"
+    version: "2.8.0"
   rudder_sdk_flutter:
     dependency: "direct main"
     description:
       path: "packages/plugins/rudder_plugin"
       relative: true
     source: path
-    version: "2.9.2"
+    version: "2.10.0"
   rudder_sdk_flutter_platform_interface:
     dependency: "direct overridden"
     description:
       path: "packages/plugins/rudder_plugin_interface"
       relative: true
     source: path
-    version: "2.8.0"
+    version: "2.9.0"
   shelf:
     dependency: transitive
     description:
@@ -780,4 +780,4 @@ packages:
     source: hosted
     version: "1.0.3"
 sdks:
-  dart: ">=3.2.0-0 <4.0.0"
+  dart: ">=3.3.0-0 <4.0.0"


### PR DESCRIPTION
## Description of the change

> Breaking Changes: Web config options have been updated as per JS SDK v3 load options.

- The mentioned web config parameters are removed:

1. maxRetryDelay
2. minRetryDelay
3. backoffFactor
4. maxAttempts
5. maxItems
6. maxBeaconItems
7. beaconFlushQueueInterval
8. autoSessionTracking
9. sessionTimeoutInMillis
10. cookieConsentManagers

 These parameters are all part of some load options. The same structure as JS is used to intake these parameters.

For example:
1. The first 5 parameters are part of queueOptions: 
queueOptions = {   maxRetryDelay: 360000,   minRetryDelay: 1000,   backoffFactor: 2,  maxAttempts: 10,   maxItems: 100 }
2.  maxBeaconItems, beaconFlushQueueInterval are part of beaconQueueOptions load option.
3. autoSessionTracking, sessionTimeoutInMillis are part of sessions load option.
4. cookieConsentManagers have been modified to consentManagement.

- New web config parameters are added

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
