### PR TITLE
Move from js_utils to js_interop to be able to compile to wasm

### DIFF
--- a/packages/plugins/rudder_plugin_web/lib/internal/web_js.dart
+++ b/packages/plugins/rudder_plugin_web/lib/internal/web_js.dart
@@ -1,47 +1,141 @@
 @JS()
 library rudder_analytics.js;
 
-import 'package:js/js.dart';
-// import 'package:rudder_sdk_flutter/RudderLogger.dart';
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
+void load(String writeKey, String dataPlaneUrl, Object? options) {
+  _load(writeKey.toJS, dataPlaneUrl.toJS, myJsify(options));
+}
+
+void setAnonymousId(String anonymousId) {
+  _setAnonymousId(anonymousId.toJS);
+}
+
+void identify(String userId, Object? traits, Object? options) {
+  _identify(userId.toJS, myJsify(traits), myJsify(options));
+}
+
+void page(String? category, String name, Object? properties, Object? options) {
+  _page(category?.toJS, name.toJS, myJsify(properties), myJsify(options));
+}
+
+void track(String event, Object? properties, Object? options) {
+  _track(event.toJS, myJsify(properties), myJsify(options));
+}
+
+void alias(String to, Object? options) {
+  _alias(to.toJS, myJsify(options));
+}
+
+void group(String groupId, Object? traits, Object? options) {
+  _group(groupId.toJS, myJsify(traits), myJsify(options));
+}
+
+void reset(bool clearAnonymousId) {
+  _reset(clearAnonymousId.toJS);
+}
+
+void startSession(int? sessionId) {
+  _startSession(sessionId?.toJS);
+}
+
+void endSession() {
+  _endSession();
+}
+
+String? getAnonymousId() {
+  final result = _getAnonymousId();
+  return result?.toDart;
+}
+
+dynamic getUserTraits() {
+  // TODO: Implement this for web
+  throw UnimplementedError('getUserTraits is not available for web yet');
+}
+
+int? getSessionId() {
+  final result = _getSessionId();
+  return result?.toDartInt;
+}
 
 @JS("rudderanalytics.load")
-external load(String writeKey, String dataPlaneUrl, dynamic options);
+external void _load(JSString writeKey, JSString dataPlaneUrl, JSAny? options);
 
-@JS("rudderanalytics.setAnonymousId")
-external setAnonymousId(String anonymousId);
+@JS('rudderanalytics.setAnonymousId')
+external void _setAnonymousId(JSString anonymousId);
 
-@JS("rudderanalytics.identify")
-external identify(String userId, dynamic traits, dynamic options);
+@JS('rudderanalytics.identify')
+external void _identify(JSString userId, JSAny? traits, JSAny? options);
 
-@JS("rudderanalytics.page")
-external page(
-    String? category, String name, dynamic properties, dynamic options);
+@JS('rudderanalytics.page')
+external void _page(
+    JSAny? category, JSString name, JSAny? properties, JSAny? options);
 
-@JS("rudderanalytics.track")
-external track(String event, dynamic properties, dynamic options);
+@JS('rudderanalytics.track')
+external void _track(JSString event, JSAny? properties, JSAny? options);
 
-@JS("rudderanalytics.alias")
-external alias(
-    String to, //Denotes the new identifier of the user.
-    dynamic options);
+@JS('rudderanalytics.alias')
+external void _alias(JSString to, JSAny? options);
 
-@JS("rudderanalytics.group")
-external group(String groupId, dynamic traits, dynamic options);
+@JS('rudderanalytics.group')
+external void _group(JSString groupId, JSAny? traits, JSAny? options);
 
-@JS("rudderanalytics.reset")
-external reset(bool clearAnonymousId);
+@JS('rudderanalytics.reset')
+external void _reset(JSBoolean clearAnonymousId);
 
-@JS("rudderanalytics.startSession")
-external startSession(int? sessionId);
+@JS('rudderanalytics.startSession')
+external void _startSession(JSAny? sessionId);
 
-@JS("rudderanalytics.endSession")
-external endSession();
+@JS('rudderanalytics.endSession')
+external void _endSession();
 
-@JS("rudderanalytics.getAnonymousId")
-external String? getAnonymousId();
+@JS('rudderanalytics.getAnonymousId')
+external JSString? _getAnonymousId();
 
-@JS("rudderanalytics.getUserTraits")
-external dynamic getUserTraits();
+@JS('rudderanalytics.getUserTraits')
+external JSAny? _getUserTraits();
 
-@JS("rudderanalytics.getSessionId")
-external int? getSessionId();
+@JS('rudderanalytics.getSessionId')
+external JSNumber? _getSessionId();
+
+JSObject newJSObject() => JSObject();
+
+JSArray newJSArray() => JSArray();
+
+extension JSArrayExt on JSArray {
+  external void push(JSAny? value);
+}
+
+JSAny? myJsify(Object? object) {
+  if (object == null) return null;
+  if (object is Map) {
+    return mapToJSObj(object);
+  } else if (object is Iterable) {
+    final jsArr = newJSArray();
+    for (final element in object) {
+      jsArr.push(myJsify(element));
+    }
+    return jsArr;
+  } else if (object is String) {
+    return object.toJS;
+  } else if (object is num) {
+    return object.toJS;
+  } else if (object is bool) {
+    return object.toJS;
+  }
+  throw ArgumentError('Unsupported type: ${object.runtimeType}');
+}
+
+JSObject mapToJSObj(Map<dynamic, dynamic> map) {
+  final jsObj = newJSObject();
+  map.forEach((k, v) {
+    if (k is! String) {
+      throw ArgumentError('Map keys must be strings. Found: ${k.runtimeType}');
+    }
+    final jsKey = k.toJS;
+    final jsValue = myJsify(v);
+    jsObj.setProperty(jsKey, jsValue);
+  });
+  return jsObj;
+}

--- a/packages/plugins/rudder_plugin_web/lib/rudder_plugin_web.dart
+++ b/packages/plugins/rudder_plugin_web/lib/rudder_plugin_web.dart
@@ -1,5 +1,5 @@
 import 'dart:async';
-import 'package:js/js_util.dart' as js;
+
 // In order to *not* need this ignore, consider extracting the "web" version
 // of your plugin as a separate package, instead of inlining it in the same
 // package as the core of your plugin.
@@ -68,39 +68,36 @@ class RudderSdkFlutterWeb extends RudderSdkPlatform {
         ?.map((key, value) => MapEntry(key, value is bool ? value : false));
     final configMap = rudderConfig.toMapWeb();
     configMap["integrations"] = integrationMap;
-    web_js.load(writeKey, rudderConfig.dataPlaneUrl, _jsify(configMap));
+    web_js.load(writeKey, rudderConfig.dataPlaneUrl, configMap);
   }
 
   @override
   void identify(String userId, {RudderTraits? traits, RudderOption? options}) {
-    web_js.identify(
-        userId, _jsify(traits?.toWebTraits()), _jsify(options?.toWebMap()));
+    web_js.identify(userId, traits?.toWebTraits(), options?.toWebMap());
   }
 
   @override
   void track(String eventName,
       {RudderProperty? properties, RudderOption? options}) {
-    web_js.track(
-        eventName, _jsify(properties?.getMap()), _jsify(options?.toWebMap()));
+    web_js.track(eventName, properties?.getMap(), options?.toWebMap());
   }
 
   @override
   void screen(String screenName,
       {String? category, RudderProperty? properties, RudderOption? options}) {
-    web_js.page(category, screenName, _jsify(properties?.getMap()),
-        _jsify(options?.toWebMap()));
+    web_js.page(
+        category, screenName, properties?.getMap(), options?.toWebMap());
   }
 
   @override
   void group(String groupId,
       {RudderTraits? groupTraits, RudderOption? options}) {
-    web_js.group(groupId, _jsify(groupTraits?.toWebTraits()),
-        _jsify(options?.toWebMap()));
+    web_js.group(groupId, groupTraits?.toWebTraits(), options?.toWebMap());
   }
 
   @override
   void alias(String newId, {RudderOption? options}) {
-    web_js.alias(newId, _jsify(options?.toWebMap()));
+    web_js.alias(newId, options?.toWebMap());
   }
 
   @override
@@ -149,31 +146,5 @@ class RudderSdkFlutterWeb extends RudderSdkPlatform {
       "traits": web_js.getUserTraits(),
       "anonymousId": web_js.getAnonymousId()
     };
-  }
-
-  dynamic _jsify(Object? object) {
-    if (object != null) {
-      // final encode =  json.encode(object);
-      // final encode = JsObject.jsify(object);
-      if (object is Map) {
-        final encode = mapToJSObj(object);
-        return encode;
-      }
-    }
-    return null;
-  }
-
-  static dynamic mapToJSObj(Map<dynamic, dynamic> map) {
-    var object = js.newObject();
-    map.forEach((k, v) {
-      var key = k;
-      var value = v is Map
-          ? mapToJSObj(v)
-          : v is Iterable
-              ? js.jsify(v)
-              : v;
-      js.setProperty(object, key, value);
-    });
-    return object;
   }
 }

--- a/packages/plugins/rudder_plugin_web/pubspec.lock
+++ b/packages/plugins/rudder_plugin_web/pubspec.lock
@@ -45,42 +45,42 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.12.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.1"
   convert:
     dependency: transitive
     description:
@@ -133,10 +133,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   file:
     dependency: transitive
     description:
@@ -200,14 +200,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
-  js:
-    dependency: "direct main"
-    description:
-      name: js
-      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.1"
   json_annotation:
     dependency: transitive
     description:
@@ -220,18 +212,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -260,10 +252,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
@@ -276,10 +268,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   package_config:
     dependency: transitive
     description:
@@ -292,10 +284,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   petitparser:
     dependency: transitive
     description:
@@ -350,60 +342,60 @@ packages:
       path: "../rudder_plugin_interface"
       relative: true
     source: path
-    version: "3.0.0"
+    version: "3.1.0"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.10.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.4.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.4"
   typed_data:
     dependency: transitive
     description:
@@ -432,10 +424,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.5"
+    version: "14.3.1"
   watcher:
     dependency: transitive
     description:
@@ -461,5 +453,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
+  dart: ">=3.7.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/packages/plugins/rudder_plugin_web/pubspec.yaml
+++ b/packages/plugins/rudder_plugin_web/pubspec.yaml
@@ -15,7 +15,6 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  js: ^0.7.1
   rudder_sdk_flutter_platform_interface: ^3.1.0
 dev_dependencies:
   flutter_lints: ^2.0.1


### PR DESCRIPTION
## Description of the change

Make rudder-sdk-flutter compile for wasm

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix #171 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved integration with JavaScript by updating the interop layer for more robust and consistent type handling.
  * Simplified data handling by removing manual Dart-to-JS conversion in favor of automatic processing.

* **Chores**
  * Streamlined internal code to reduce complexity and improve maintainability, with no changes to the user-facing interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->