### PR TITLE
refactor: use js_interop methods for value conversion in web plugin

### DIFF
--- a/packages/plugins/rudder_plugin_web/lib/internal/web_js.dart
+++ b/packages/plugins/rudder_plugin_web/lib/internal/web_js.dart
@@ -3,142 +3,41 @@ library rudder_analytics.js;
 
 import 'dart:js_interop';
 
-void load(String writeKey, String dataPlaneUrl, Map<String, dynamic>? options) {
-  _load(writeKey.toJS, dataPlaneUrl.toJS, mapToJSObj(options));
-}
-
-void setAnonymousId(String anonymousId) {
-  _setAnonymousId(anonymousId.toJS);
-}
-
-void identify(String userId, Map<String, dynamic>? traits,
-    Map<String, dynamic>? options) {
-  _identify(userId.toJS, mapToJSObj(traits), mapToJSObj(options));
-}
-
-void page(String? category, String name, Map<String, dynamic>? properties,
-    Map<String, dynamic>? options) {
-  _page(category?.toJS, name.toJS, mapToJSObj(properties), mapToJSObj(options));
-}
-
-void track(String event, Map<String, dynamic>? properties,
-    Map<String, dynamic>? options) {
-  _track(event.toJS, mapToJSObj(properties), mapToJSObj(options));
-}
-
-void alias(String to, Map<String, dynamic>? options) {
-  _alias(to.toJS, mapToJSObj(options));
-}
-
-void group(String groupId, Map<String, dynamic>? traits,
-    Map<String, dynamic>? options) {
-  _group(groupId.toJS, mapToJSObj(traits), mapToJSObj(options));
-}
-
-void reset(bool clearAnonymousId) {
-  _reset(clearAnonymousId.toJS);
-}
-
-void startSession(int? sessionId) {
-  _startSession(sessionId?.toJS);
-}
-
-void endSession() {
-  _endSession();
-}
-
-String? getAnonymousId() {
-  final result = _getAnonymousId();
-  return result?.toDart;
-}
-
-dynamic getUserTraits() {
-  final result = _getUserTraits();
-  return result?.dartify();
-}
-
-int? getSessionId() {
-  final result = _getSessionId();
-  return result?.toDartInt;
-}
-
 @JS("load")
-external void _load(
-    JSString writeKey, JSString dataPlaneUrl, JSObject? options);
+external void load(JSString writeKey, JSString dataPlaneUrl, JSObject? options);
 
 @JS('setAnonymousId')
-external void _setAnonymousId(JSString anonymousId);
+external void setAnonymousId(JSString anonymousId);
 
 @JS('identify')
-external void _identify(JSString userId, JSObject? traits, JSObject? options);
+external void identify(JSString userId, JSObject? traits, JSObject? options);
 
 @JS('page')
-external void _page(
-    JSString? category, JSString name, JSObject? properties, JSObject? options);
+external void page(JSString? category, JSString name, JSObject? properties, JSObject? options);
 
 @JS('track')
-external void _track(JSString event, JSObject? properties, JSObject? options);
+external void track(JSString event, JSObject? properties, JSObject? options);
 
 @JS('alias')
-external void _alias(JSString to, JSObject? options);
+external void alias(JSString to, JSObject? options);
 
 @JS('group')
-external void _group(JSString groupId, JSObject? traits, JSObject? options);
+external void group(JSString groupId, JSObject? traits, JSObject? options);
 
 @JS('reset')
-external void _reset(JSBoolean clearAnonymousId);
+external void reset(JSBoolean clearAnonymousId);
 
 @JS('startSession')
-external void _startSession(JSNumber? sessionId);
+external void startSession(JSNumber? sessionId);
 
 @JS('endSession')
-external void _endSession();
+external void endSession();
 
 @JS('getAnonymousId')
-external JSString? _getAnonymousId();
+external JSString? getAnonymousId();
 
 @JS('getUserTraits')
-external JSObject? _getUserTraits();
+external JSObject? getUserTraits();
 
 @JS('getSessionId')
-external JSNumber? _getSessionId();
-
-extension JSArrayExt on JSArray {
-  external void push(JSAny? value);
-}
-
-extension JSObjectExt on JSObject {
-  external void operator []=(JSString key, JSAny? value);
-}
-
-JSAny? convertToJS(Object? object) {
-  if (object == null) return null;
-  if (object is Map<String, dynamic>) {
-    return mapToJSObj(object);
-  } else if (object is Iterable) {
-    final jsArr = JSArray();
-    for (final element in object) {
-      jsArr.push(convertToJS(element));
-    }
-    return jsArr;
-  } else if (object is String) {
-    return object.toJS;
-  } else if (object is num) {
-    return object.toJS;
-  } else if (object is bool) {
-    return object.toJS;
-  }
-
-  throw ArgumentError('Unsupported type: ${object.runtimeType}');
-}
-
-JSObject? mapToJSObj(Map<String, dynamic>? map) {
-  if (map == null) return null;
-  final jsObj = JSObject();
-  map.forEach((k, v) {
-    final jsKey = k.toJS;
-    final jsValue = convertToJS(v);
-    jsObj[jsKey] = jsValue;
-  });
-  return jsObj;
-}
+external JSNumber? getSessionId();

--- a/packages/plugins/rudder_plugin_web/lib/rudder_plugin_web.dart
+++ b/packages/plugins/rudder_plugin_web/lib/rudder_plugin_web.dart
@@ -1,5 +1,5 @@
 import 'dart:async';
-
+import 'dart:js_interop';
 // In order to *not* need this ignore, consider extracting the "web" version
 // of your plugin as a separate package, instead of inlining it in the same
 // package as the core of your plugin.
@@ -68,41 +68,42 @@ class RudderSdkFlutterWeb extends RudderSdkPlatform {
         ?.map((key, value) => MapEntry(key, value is bool ? value : false));
     final configMap = rudderConfig.toMapWeb();
     configMap["integrations"] = integrationMap;
-    web_js.load(writeKey, rudderConfig.dataPlaneUrl, configMap);
+    web_js.load(writeKey.toJS, rudderConfig.dataPlaneUrl.toJS, configMap.jsify() as JSObject?);
   }
 
   @override
   void identify(String userId, {RudderTraits? traits, RudderOption? options}) {
-    web_js.identify(userId, traits?.toWebTraits(), options?.toWebMap());
+    web_js.identify(userId.toJS, traits?.toWebTraits()?.jsify() as JSObject?, options?.toWebMap()?.jsify() as JSObject?);
   }
 
   @override
   void track(String eventName,
       {RudderProperty? properties, RudderOption? options}) {
-    web_js.track(eventName, properties?.getMap(), options?.toWebMap());
+    web_js.track(eventName.toJS, properties?.getMap()?.jsify() as JSObject?, options?.toWebMap()?.jsify() as JSObject?);
   }
 
   @override
   void screen(String screenName,
       {String? category, RudderProperty? properties, RudderOption? options}) {
-    web_js.page(
-        category, screenName, properties?.getMap(), options?.toWebMap());
+    web_js.page(category?.toJS, screenName.toJS, properties?.getMap()?.jsify() as JSObject?,
+        options?.toWebMap()?.jsify() as JSObject?);
   }
 
   @override
   void group(String groupId,
       {RudderTraits? groupTraits, RudderOption? options}) {
-    web_js.group(groupId, groupTraits?.toWebTraits(), options?.toWebMap());
+    web_js.group(groupId.toJS, groupTraits?.toWebTraits()?.jsify() as JSObject?,
+        options?.toWebMap()?.jsify() as JSObject?);
   }
 
   @override
   void alias(String newId, {RudderOption? options}) {
-    web_js.alias(newId, options?.toWebMap());
+    web_js.alias(newId.toJS, options?.toWebMap()?.jsify() as JSObject?);
   }
 
   @override
   void reset({bool clearAnonymousId = false}) {
-    web_js.reset(clearAnonymousId);
+    web_js.reset(clearAnonymousId.toJS);
   }
 
   @override
@@ -122,12 +123,12 @@ class RudderSdkFlutterWeb extends RudderSdkPlatform {
 
   @override
   void putAnonymousId(String anonymousId) {
-    web_js.setAnonymousId(anonymousId);
+    web_js.setAnonymousId(anonymousId.toJS);
   }
 
   @override
   void startSession({int? sessionId}) {
-    web_js.startSession(sessionId);
+    web_js.startSession(sessionId?.toJS);
   }
 
   @override
@@ -137,14 +138,14 @@ class RudderSdkFlutterWeb extends RudderSdkPlatform {
 
   @override
   Future<int?> getSessionId() async {
-    return web_js.getSessionId();
+    return web_js.getSessionId()?.toDartInt;
   }
 
   @override
-  Future<Map?> getRudderContext() async {
+  Future<Map?> getRudderContext() async {    
     return {
-      "traits": web_js.getUserTraits(),
-      "anonymousId": web_js.getAnonymousId()
+      "traits": web_js.getUserTraits()?.dartify(),
+      "anonymousId": web_js.getAnonymousId()?.toDart
     };
   }
 }


### PR DESCRIPTION
# PR Description

## Summary
Refactor web plugin to use direct js_interop methods for improved WASM compatibility

## Changes
- **Simplified JS interop layer**: Removed wrapper functions in `web_js.dart` and made external JS functions directly accessible
- **Eliminated custom conversion utilities**: Removed `convertToJS()`, `mapToJSObj()`, and related extension methods in favor of built-in `jsify()` method
- **Updated method calls**: Modified all web plugin method calls to use direct JS interop with `.toJS` conversions and `jsify()` for complex objects
- **Improved type safety**: Used proper JS types (`JSString`, `JSObject`, `JSBoolean`, `JSNumber`) directly in external function declarations

## Technical Details
- Reduced code complexity by ~100 lines while maintaining the same functionality
- Leveraged Dart's built-in `jsify()` and type conversion methods instead of custom implementations
- This approach provides better WASM support and follows current Dart js_interop best practices

## Files Modified
- `packages/plugins/rudder_plugin_web/lib/internal/web_js.dart`: Simplified external JS function declarations
- `packages/plugins/rudder_plugin_web/lib/rudder_plugin_web.dart`: Updated to use direct js_interop methods

## Test Plan
- [ ] Verify all web plugin functionality works correctly
- [ ] Test WASM compatibility if applicable
- [ ] Ensure no breaking changes in public API

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal handling of JavaScript interop to streamline type conversions between Dart and JavaScript.
  * Removed redundant Dart-side wrappers and helper methods for JS interop, simplifying the underlying implementation.
  * No changes to the public interface or visible features for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->