### PR TITLE
fix: address snyk issue in amplitude

### DIFF
--- a/packages/integrations/rudder_integration_amplitude_flutter/android/build.gradle
+++ b/packages/integrations/rudder_integration_amplitude_flutter/android/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     implementation 'com.rudderstack.android.sdk:core:[1.7.0, 2.0.0)'
     implementation project(path: ':rudder_plugin_android')
     // Rudder-Amplitude Android Device Mode
-    implementation 'com.rudderstack.android.integration:amplitude:1.0.1'
+    implementation 'com.rudderstack.android.integration:amplitude:[1.0.1, 2.0.0)'
     // Amplitude SDK Dependencies
     implementation 'com.amplitude:android-sdk:2.25.2'
     implementation 'com.squareup.okhttp3:okhttp:4.2.2'


### PR DESCRIPTION
## Description of the change

- Address the snyk issue in Amplitude Android. By updating the version range for the `com.rudderstack.android.integration:amplitude` dependency in the `build.gradle` file to allow compatibility with versions up to 2.0.0.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a library dependency to allow for a wider range of compatible versions, improving flexibility for future updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->