### PR TITLE
ci: fix deploy to pub.dev action

### DIFF
--- a/.github/workflows/deploy-pubdev.yml
+++ b/.github/workflows/deploy-pubdev.yml
@@ -22,10 +22,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Checkout to main
-        if: github.event.workflow_run.conclusion == 'success'
-        run: git checkout main
+          # For workflow_run triggers, explicitly use main branch
+          # For other triggers (tags, manual), use the default ref
+          ref: ${{ github.event.workflow_run.conclusion == 'success' && 'main' || github.ref }}
 
       - name: Setup Dart
         uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c #v1.3

--- a/.github/workflows/deploy-pubdev.yml
+++ b/.github/workflows/deploy-pubdev.yml
@@ -20,6 +20,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout to main
+        if: github.event.workflow_run.conclusion == 'success'
+        run: git checkout main
 
       - name: Setup Dart
         uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c #v1.3

--- a/.github/workflows/deploy-pubdev.yml
+++ b/.github/workflows/deploy-pubdev.yml
@@ -60,37 +60,37 @@ jobs:
           echo "CURRENT_VERSION_VALUE=$current_version" >> $GITHUB_ENV
           echo "DATE=$(date)" >> $GITHUB_ENV
 
-      - name: Send message to Slack channel
-        id: slack
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a  # v2.1.1
-        env:
-          PROJECT_NAME: 'Flutter SDK pub.dev packages'
-          RELEASES_URL: 'https://pub.dev/packages?q=rudder'
-        with:
-          method: chat.postMessage
-          payload-templated: true
-          retries: rapid
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload: |
-            {
-              "channel": "${{ secrets.SLACK_RELEASE_CHANNEL_ID }}",
-              "blocks": [
-                {
-                  "type": "header",
-                  "text": {
-                    "type": "plain_text",
-                    "text": "New release: ${{ env.PROJECT_NAME }}"
-                  }
-                },
-                {
-                  "type": "divider"
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*Release: <${{ env.RELEASES_URL }}|Latest Packages>*\n${{ env.DATE }}"
-                  }
-                }
-              ]
-            }
+      # - name: Send message to Slack channel
+      #   id: slack
+      #   uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a  # v2.1.1
+      #   env:
+      #     PROJECT_NAME: 'Flutter SDK pub.dev packages'
+      #     RELEASES_URL: 'https://pub.dev/packages?q=rudder'
+      #   with:
+      #     method: chat.postMessage
+      #     payload-templated: true
+      #     retries: rapid
+      #     token: ${{ secrets.SLACK_BOT_TOKEN }}
+      #     payload: |
+      #       {
+      #         "channel": "${{ secrets.SLACK_RELEASE_CHANNEL_ID }}",
+      #         "blocks": [
+      #           {
+      #             "type": "header",
+      #             "text": {
+      #               "type": "plain_text",
+      #               "text": "New release: ${{ env.PROJECT_NAME }}"
+      #             }
+      #           },
+      #           {
+      #             "type": "divider"
+      #           },
+      #           {
+      #             "type": "section",
+      #             "text": {
+      #               "type": "mrkdwn",
+      #               "text": "*Release: <${{ env.RELEASES_URL }}|Latest Packages>*\n${{ env.DATE }}"
+      #             }
+      #           }
+      #         ]
+      #       }

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -78,37 +78,37 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Send message to Slack channel
-        id: slack
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a  # v2.1.1
-        env:
-          PROJECT_NAME: 'Flutter SDK monorepo (v2.x)'
-          RELEASES_URL: 'https://github.com/rudderlabs/rudder-sdk-flutter/releases/'
-        with:
-          method: chat.postMessage
-          payload-templated: true
-          retries: rapid
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload: |
-            {
-              "channel": "${{ secrets.SLACK_RELEASE_CHANNEL_ID }}",
-              "blocks": [
-                {
-                  "type": "header",
-                  "text": {
-                    "type": "plain_text",
-                    "text": "New release: ${{ env.PROJECT_NAME }}"
-                  }
-                },
-                {
-                  "type": "divider"
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*Release: <${{env.RELEASES_URL}}${{ steps.extract-version.outputs.release_version }}|v${{ steps.extract-version.outputs.release_version }}>*\n${{ env.DATE }}"
-                  }
-                }
-              ]
-            }
+      # - name: Send message to Slack channel
+      #   id: slack
+      #   uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a  # v2.1.1
+      #   env:
+      #     PROJECT_NAME: 'Flutter SDK monorepo (v2.x)'
+      #     RELEASES_URL: 'https://github.com/rudderlabs/rudder-sdk-flutter/releases/'
+      #   with:
+      #     method: chat.postMessage
+      #     payload-templated: true
+      #     retries: rapid
+      #     token: ${{ secrets.SLACK_BOT_TOKEN }}
+      #     payload: |
+      #       {
+      #         "channel": "${{ secrets.SLACK_RELEASE_CHANNEL_ID }}",
+      #         "blocks": [
+      #           {
+      #             "type": "header",
+      #             "text": {
+      #               "type": "plain_text",
+      #               "text": "New release: ${{ env.PROJECT_NAME }}"
+      #             }
+      #           },
+      #           {
+      #             "type": "divider"
+      #           },
+      #           {
+      #             "type": "section",
+      #             "text": {
+      #               "type": "mrkdwn",
+      #               "text": "*Release: <${{env.RELEASES_URL}}${{ steps.extract-version.outputs.release_version }}|v${{ steps.extract-version.outputs.release_version }}>*\n${{ env.DATE }}"
+      #             }
+      #           }
+      #         ]
+      #       }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -171,106 +171,93 @@ packages:
   rudder_integration_adjust_flutter:
     dependency: "direct main"
     description:
-      name: rudder_integration_adjust_flutter
-      sha256: "8244e1562cca2acf8972f52146d8755adf809c0377dacf56f3cb02f4ed3bcf8c"
-      url: "https://pub.dev"
-    source: hosted
+      path: "../packages/integrations/rudder_integration_adjust_flutter"
+      relative: true
+    source: path
     version: "2.2.0"
   rudder_integration_amplitude_flutter:
     dependency: "direct main"
     description:
-      name: rudder_integration_amplitude_flutter
-      sha256: cfffda407f6e640ae0e90755f2ad764c3d4ce7b3493284550e7e520f8d7cd492
-      url: "https://pub.dev"
-    source: hosted
+      path: "../packages/integrations/rudder_integration_amplitude_flutter"
+      relative: true
+    source: path
     version: "2.2.1"
   rudder_integration_appcenter_flutter:
     dependency: "direct main"
     description:
-      name: rudder_integration_appcenter_flutter
-      sha256: "9fd12df96443b715264ed512074fdc8f0822d4be647300b6847394ec47ba201e"
-      url: "https://pub.dev"
-    source: hosted
+      path: "../packages/integrations/rudder_integration_appcenter_flutter"
+      relative: true
+    source: path
     version: "2.2.0"
   rudder_integration_appsflyer_flutter:
     dependency: "direct main"
     description:
-      name: rudder_integration_appsflyer_flutter
-      sha256: "522ad7555c1fd4c15ed300bb82f2ecd707796ad782ef55c6f2d9e55ef9c09149"
-      url: "https://pub.dev"
-    source: hosted
+      path: "../packages/integrations/rudder_integration_appsflyer_flutter"
+      relative: true
+    source: path
     version: "1.3.0"
   rudder_integration_braze_flutter:
     dependency: "direct main"
     description:
-      name: rudder_integration_braze_flutter
-      sha256: "4bec55a7ab37f9e3e8fa162329c2d35131619cb2ab3be6b54713965d21af42e4"
-      url: "https://pub.dev"
-    source: hosted
+      path: "../packages/integrations/rudder_integration_braze_flutter"
+      relative: true
+    source: path
     version: "2.3.0"
   rudder_integration_firebase_flutter:
     dependency: "direct main"
     description:
-      name: rudder_integration_firebase_flutter
-      sha256: bca7369ae9feae1883f3aa0754d7890d7517c11e6bcc4c3ecbe9669b99ebdf50
-      url: "https://pub.dev"
-    source: hosted
+      path: "../packages/integrations/rudder_integration_firebase_flutter"
+      relative: true
+    source: path
     version: "4.3.0"
   rudder_integration_leanplum_flutter:
     dependency: "direct main"
     description:
-      name: rudder_integration_leanplum_flutter
-      sha256: a55f91edd4ff591d0ad8dd2dd75239fc9cd3797356615b5e3169799c7b11e8db
-      url: "https://pub.dev"
-    source: hosted
+      path: "../packages/integrations/rudder_integration_leanplum_flutter"
+      relative: true
+    source: path
     version: "2.2.0"
   rudder_plugin_android:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: rudder_plugin_android
-      sha256: "1528cd34ff9c5194f03fbf6449f9a4ab8aea65565807e27e49582de2b1e6dd70"
-      url: "https://pub.dev"
-    source: hosted
+      path: "../packages/plugins/rudder_plugin_android"
+      relative: true
+    source: path
     version: "3.1.1"
   rudder_plugin_db_encryption:
     dependency: "direct main"
     description:
-      name: rudder_plugin_db_encryption
-      sha256: ecaeb66bebd66d5e80e4b8faf38422b95ee3715aad31a389cd92b06ce6795cc1
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.3.0"
+      path: "../packages/plugins/rudder_plugin_db_encryption"
+      relative: true
+    source: path
+    version: "1.4.0"
   rudder_plugin_ios:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: rudder_plugin_ios
-      sha256: ffbbc23625fb784923fce7c60a31c5cd2fc9d7dc9eb1ecc775ac1c9ecb46729d
-      url: "https://pub.dev"
-    source: hosted
+      path: "../packages/plugins/rudder_plugin_ios"
+      relative: true
+    source: path
     version: "3.1.1"
   rudder_plugin_web:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: rudder_plugin_web
-      sha256: e81f597216bdf9b8d01ea1fa33fb10e6de818cea4a8aa79898dfe741e5b1a456
-      url: "https://pub.dev"
-    source: hosted
+      path: "../packages/plugins/rudder_plugin_web"
+      relative: true
+    source: path
     version: "3.1.0"
   rudder_sdk_flutter:
     dependency: "direct main"
     description:
-      name: rudder_sdk_flutter
-      sha256: "4c9b006a468ed48a4317a8dbbfdaddab97a8b5462f398c01568143a792091233"
-      url: "https://pub.dev"
-    source: hosted
+      path: "../packages/plugins/rudder_plugin"
+      relative: true
+    source: path
     version: "3.2.0"
   rudder_sdk_flutter_platform_interface:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: rudder_sdk_flutter_platform_interface
-      sha256: "589454f67fc8178cfb18c5140c27c419e09155c4a928f796b10565ca028e14b3"
-      url: "https://pub.dev"
-    source: hosted
+      path: "../packages/plugins/rudder_plugin_interface"
+      relative: true
+    source: path
     version: "3.2.0"
   sky_engine:
     dependency: transitive


### PR DESCRIPTION
## Description of the change

- When we merge the release PR, a dummy release action is triggered which doesn't attempt to release Flutter packages. I believe this might be happening because we don't perform checkout to main (like we do in React Native, refer [here](https://github.com/rudderlabs/rudder-sdk-react-native/blob/1b94d7ba3fadb7c1de7aeaff64261a0db56edd19/.github/workflows/deploy-npm.yml#L21-L23)).
- This PR attempts to fix that issue.
- The workflow now intelligently determines which ref to checkout based on the trigger type:
  1. When triggered by workflow_run (after release PR merge): Checks out main branch to get the latest changes
  2. When triggered by a tag push: Uses that specific tag
  3. When triggered manually: Uses whatever ref is specified
- This solves the issue where the workflow was checking out the wrong commit when triggered after a release PR merge, which caused melos to not find any packages to publish.


## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
