### PR TITLE
fix: make the state variables static

### DIFF
--- a/packages/plugins/rudder_plugin_android/android/src/main/java/com/rudderstack/sdk/flutter/RudderSdkFlutterPlugin.java
+++ b/packages/plugins/rudder_plugin_android/android/src/main/java/com/rudderstack/sdk/flutter/RudderSdkFlutterPlugin.java
@@ -46,8 +46,7 @@ public class RudderSdkFlutterPlugin implements FlutterPlugin, MethodCallHandler 
 
   public static AtomicBoolean isInitialized = new AtomicBoolean(false);
   private static boolean autoTrackLifeCycleEvents = true;
-  // TODO: Make this static
-  private boolean autoRecordScreenViews = false;
+  private static boolean autoRecordScreenViews = false;
 
   private static boolean autoSessionTracking = true;
   private static Long sessionTimeoutInMilliSeconds = 300000L;

--- a/packages/plugins/rudder_plugin_android/android/src/main/java/com/rudderstack/sdk/flutter/managers/ActivityLifeCycleManager.java
+++ b/packages/plugins/rudder_plugin_android/android/src/main/java/com/rudderstack/sdk/flutter/managers/ActivityLifeCycleManager.java
@@ -16,15 +16,15 @@ import static com.rudderstack.sdk.flutter.LifeCycleRunnables.ScreenViewRunnable;
 import com.rudderstack.sdk.flutter.RudderSdkFlutterPlugin;
 
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class ActivityLifeCycleManager implements Application.ActivityLifecycleCallbacks {
-  private AtomicInteger noOfActivities;
-  private boolean fromBackground = false;
+  private static final AtomicInteger noOfActivities = new AtomicInteger(0);
+  private static final AtomicBoolean fromBackground = new AtomicBoolean(false);
   private Application application;
   private final RudderSdkFlutterPlugin plugin;
 
   ActivityLifeCycleManager(Context context, RudderSdkFlutterPlugin plugin) {
-    this.noOfActivities = new AtomicInteger(0);
     this.application = (Application) context.getApplicationContext();
     this.plugin = plugin;
     this.application.registerActivityLifecycleCallbacks(this);
@@ -50,7 +50,7 @@ public class ActivityLifeCycleManager implements Application.ActivityLifecycleCa
   @Override
   public void onActivityStarted(@NonNull Activity activity) {
     if (noOfActivities.incrementAndGet() == 1) {
-      executeRunnableLifeCycleEvent(this.plugin, new ApplicationOpenedRunnable(fromBackground));
+      executeRunnableLifeCycleEvent(this.plugin, new ApplicationOpenedRunnable(fromBackground.get()));
     }
     executeRunnableLifeCycleEvent(this.plugin, new ScreenViewRunnable(activity.getLocalClassName()));
   }
@@ -69,7 +69,7 @@ public class ActivityLifeCycleManager implements Application.ActivityLifecycleCa
 
   @Override
   public void onActivityStopped(@NonNull Activity activity) {
-    fromBackground = true;
+    fromBackground.set(true);
     if (noOfActivities.decrementAndGet() == 0) {
       executeRunnableLifeCycleEvent(this.plugin, new ApplicationBackgroundedRunnable());
     }


### PR DESCRIPTION
## Description of the change

- In this PR, we have ensured, all the state variables (including session and screen tracking) are made static.
- This would fix the following issue:
    - Automatic screen tracking not working properly.
    - Application Opened event not having the correct value for `from_background`, when app is moved to background using back button and opened again.
    - SessionId not being reset properly, when app is moved to background using back button and opened again.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of automatic screen view tracking across the app, eliminating per-instance discrepancies.
  * Enhanced reliability of foreground/background detection to reduce missed or duplicate “app opened” events during rapid activity changes.
  * Increased stability of event tracking on Android under concurrent lifecycle transitions.
  * No configuration changes required; behavior is more consistent and robust by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->