### PR TITLE
feat(core): remove WASM-incompatible logger dependency

### DIFF
--- a/packages/plugins/rudder_plugin/pubspec.lock
+++ b/packages/plugins/rudder_plugin/pubspec.lock
@@ -76,26 +76,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "8dcda04c3fc16c14f48a7bb586d4be1f0d1572731b6d81d51772ef47c02081e0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.1"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -155,30 +155,34 @@ packages:
   rudder_plugin_android:
     dependency: "direct main"
     description:
-      path: "../rudder_plugin_android"
-      relative: true
-    source: path
+      name: rudder_plugin_android
+      sha256: "1528cd34ff9c5194f03fbf6449f9a4ab8aea65565807e27e49582de2b1e6dd70"
+      url: "https://pub.dev"
+    source: hosted
     version: "3.1.1"
   rudder_plugin_ios:
     dependency: "direct main"
     description:
-      path: "../rudder_plugin_ios"
-      relative: true
-    source: path
+      name: rudder_plugin_ios
+      sha256: ffbbc23625fb784923fce7c60a31c5cd2fc9d7dc9eb1ecc775ac1c9ecb46729d
+      url: "https://pub.dev"
+    source: hosted
     version: "3.1.1"
   rudder_plugin_web:
     dependency: "direct main"
     description:
-      path: "../rudder_plugin_web"
-      relative: true
-    source: path
+      name: rudder_plugin_web
+      sha256: e81f597216bdf9b8d01ea1fa33fb10e6de818cea4a8aa79898dfe741e5b1a456
+      url: "https://pub.dev"
+    source: hosted
     version: "3.1.0"
   rudder_sdk_flutter_platform_interface:
     dependency: "direct main"
     description:
-      path: "../rudder_plugin_interface"
-      relative: true
-    source: path
+      name: rudder_sdk_flutter_platform_interface
+      sha256: "589454f67fc8178cfb18c5140c27c419e09155c4a928f796b10565ca028e14b3"
+      url: "https://pub.dev"
+    source: hosted
     version: "3.2.0"
   sky_engine:
     dependency: transitive
@@ -229,18 +233,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.6"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:

--- a/packages/plugins/rudder_plugin_interface/lib/src/rudder_logger.dart
+++ b/packages/plugins/rudder_plugin_interface/lib/src/rudder_logger.dart
@@ -1,5 +1,3 @@
-import 'package:logger/logger.dart';
-
 class RudderLogger {
   static const int VERBOSE = 5;
   static const int DEBUG = 4;
@@ -10,9 +8,6 @@ class RudderLogger {
 
   static int __logLevel = INFO;
   static const String __TAG = "RudderFlutterSDK";
-  static final Logger _logger = Logger(
-    printer: PrettyPrinter(),
-  );
 
   static void init(int l) {
     if (l > VERBOSE) {
@@ -25,31 +20,31 @@ class RudderLogger {
 
   static void logError(String message) {
     if (__logLevel >= ERROR) {
-      _logger.e(__TAG, error: "Error: $message");
+      print('$__TAG Error: $message');
     }
   }
 
   static void logWarn(String message) {
     if (__logLevel >= WARN) {
-      _logger.w(__TAG, error: "Warn: $message");
+      print('$__TAG Warn: $message');
     }
   }
 
   static void logInfo(String message) {
     if (__logLevel >= INFO) {
-      _logger.i(__TAG, error: "Info: $message");
+      print('$__TAG Info: $message');
     }
   }
 
   static void logDebug(String message) {
     if (__logLevel >= DEBUG) {
-      _logger.d(__TAG, error: "Debug: $message");
+      print('$__TAG Debug: $message');
     }
   }
 
   static void logVerbose(String message) {
     if (__logLevel >= VERBOSE) {
-      _logger.v(__TAG, error: "Verbose: $message");
+      print('$__TAG Verbose: $message');
     }
   }
 }

--- a/packages/plugins/rudder_plugin_interface/pubspec.lock
+++ b/packages/plugins/rudder_plugin_interface/pubspec.lock
@@ -71,26 +71,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "8dcda04c3fc16c14f48a7bb586d4be1f0d1572731b6d81d51772ef47c02081e0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.1"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -99,14 +99,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
-  logger:
-    dependency: "direct main"
-    description:
-      name: logger
-      sha256: "55d6c23a6c15db14920e037fe7e0dc32e7cdaf3b64b4b25df2d541b5b6b81c0c"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.6.1"
   matcher:
     dependency: transitive
     description:
@@ -196,18 +188,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.6"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:

--- a/packages/plugins/rudder_plugin_interface/pubspec.yaml
+++ b/packages/plugins/rudder_plugin_interface/pubspec.yaml
@@ -13,7 +13,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  logger: ^2.0.2
   plugin_platform_interface: ^2.0.0
 
 dev_dependencies:


### PR DESCRIPTION
## Description of the change

- Replace `logger` package with native `print()` statements in `RudderLogger` to achieve WASM compatibility.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
