### PR TITLE
feat: add deeplink tracking flag

### DIFF
--- a/packages/plugins/rudder_plugin_android/android/src/main/java/com/rudderstack/sdk/flutter/parsers/RudderConfigParser.java
+++ b/packages/plugins/rudder_plugin_android/android/src/main/java/com/rudderstack/sdk/flutter/parsers/RudderConfigParser.java
@@ -26,6 +26,7 @@ public class RudderConfigParser {
       .withCollectDeviceId((Boolean) configMap.get("collectDeviceId"))
       .withControlPlaneUrl((String) configMap.get("controlPlaneUrl"))
       .withGzip((Boolean) configMap.get("gzip"))
+      .withTrackDeepLinks((Boolean) configMap.get("trackDeepLinks"))
       // disabling the below three flags on the native side as they are handled on the flutter side
       .withTrackLifecycleEvents(false)
       .withRecordScreenViews(false)

--- a/packages/plugins/rudder_plugin_interface/lib/src/constants.dart
+++ b/packages/plugins/rudder_plugin_interface/lib/src/constants.dart
@@ -48,6 +48,9 @@ class Constants {
   // whether we should record screen views automatically
   static const bool RECORD_SCREEN_VIEWS = false;
 
+  // whether we should track deep links automatically
+  static const bool TRACK_DEEP_LINKS = true;
+
   static const DataResidencyServer DEFAULT_DATA_RESIDENCY_SERVER =
       DataResidencyServer.US;
 }

--- a/packages/plugins/rudder_plugin_interface/lib/src/models/rudder_config.dart
+++ b/packages/plugins/rudder_plugin_interface/lib/src/models/rudder_config.dart
@@ -117,6 +117,7 @@ class RudderConfig {
             mobileConfig.sessionTimeoutInMillis;
       }
       _mobileConfigMap['gzip'] = mobileConfig.gzip;
+      _mobileConfigMap['trackDeepLinks'] = mobileConfig.trackDeepLinks;
     }
     if (Utils.isEmpty(controlPlaneUrl)) {
       RudderLogger.logError(

--- a/packages/plugins/rudder_plugin_interface/lib/src/models/rudder_mobile_config.dart
+++ b/packages/plugins/rudder_plugin_interface/lib/src/models/rudder_mobile_config.dart
@@ -35,6 +35,9 @@ class MobileConfig {
   /// @param gzip whether to gzip compress the request payload or not
   final bool _gzip;
 
+  /// @param trackDeepLinks whether to track deep links automatically (Android only)
+  final bool _trackDeepLinks;
+
   MobileConfig(
       {dbCountThreshold = Constants.DB_COUNT_THRESHOLD,
       autoCollectAdvertId = Constants.AUTO_COLLECT_ADVERT_ID,
@@ -46,7 +49,8 @@ class MobileConfig {
       DBEncryptionInterface? dbEncryption,
       autoSessionTracking = Constants.AUTO_SESSION_TRACKING,
       sessionTimeoutInMillis = Constants.DEFAULT_SESSION_TIMEOUT_MOBILE,
-      gzip = Constants.DEFAULT_GZIP_COMPRESSION})
+      gzip = Constants.DEFAULT_GZIP_COMPRESSION,
+      trackDeepLinks = Constants.TRACK_DEEP_LINKS})
       : _dbCountThreshold = dbCountThreshold,
         _autoCollectAdvertId = autoCollectAdvertId,
         _collectDeviceId = collectDeviceId,
@@ -57,7 +61,8 @@ class MobileConfig {
         _dbEncryption = dbEncryption,
         _autoSessionTracking = autoSessionTracking,
         _sessionTimeoutInMillis = sessionTimeoutInMillis,
-        _gzip = gzip;
+        _gzip = gzip,
+        _trackDeepLinks = trackDeepLinks;
 
   int get dbCountThreshold => _dbCountThreshold;
 
@@ -80,4 +85,6 @@ class MobileConfig {
   int get sessionTimeoutInMillis => _sessionTimeoutInMillis;
 
   bool get gzip => _gzip;
+
+  bool get trackDeepLinks => _trackDeepLinks;
 }

--- a/packages/plugins/rudder_plugin_interface/test/src/models/rudder_config_test.dart
+++ b/packages/plugins/rudder_plugin_interface/test/src/models/rudder_config_test.dart
@@ -191,4 +191,44 @@ void main() {
     expect(webMap["residencyServer"], equals("US"));
     expect(mobileMap["dataResidencyServer"], equals("US"));
   });
+
+  test('trackDeepLinks configuration parameter is properly handled', () {
+    // Test with trackDeepLinks set to true
+    final MobileConfig mobileConfigTrue = MobileConfig(trackDeepLinks: true);
+    RudderConfig configTrue = RudderConfigBuilder()
+        .withMobileConfig(mobileConfigTrue)
+        .build();
+    Map<String, dynamic> mobileMapTrue = configTrue.toMapMobile();
+    expect(mobileMapTrue["trackDeepLinks"], equals(true));
+
+    // Test with trackDeepLinks set to false
+    final MobileConfig mobileConfigFalse = MobileConfig(trackDeepLinks: false);
+    RudderConfig configFalse = RudderConfigBuilder()
+        .withMobileConfig(mobileConfigFalse)
+        .build();
+    Map<String, dynamic> mobileMapFalse = configFalse.toMapMobile();
+    expect(mobileMapFalse["trackDeepLinks"], equals(false));
+
+    // Test with default value (should be true)
+    final MobileConfig mobileConfigDefault = MobileConfig();
+    RudderConfig configDefault = RudderConfigBuilder()
+        .withMobileConfig(mobileConfigDefault)
+        .build();
+    Map<String, dynamic> mobileMapDefault = configDefault.toMapMobile();
+    expect(mobileMapDefault["trackDeepLinks"], equals(true));
+  });
+
+  test('MobileConfig trackDeepLinks getter works correctly', () {
+    // Test getter with explicit true value
+    final MobileConfig configTrue = MobileConfig(trackDeepLinks: true);
+    expect(configTrue.trackDeepLinks, equals(true));
+
+    // Test getter with explicit false value
+    final MobileConfig configFalse = MobileConfig(trackDeepLinks: false);
+    expect(configFalse.trackDeepLinks, equals(false));
+
+    // Test getter with default value
+    final MobileConfig configDefault = MobileConfig();
+    expect(configDefault.trackDeepLinks, equals(true));
+  });
 }

--- a/packages/plugins/rudder_plugin_ios/ios/Classes/RudderSdkFlutterPlugin.m
+++ b/packages/plugins/rudder_plugin_ios/ios/Classes/RudderSdkFlutterPlugin.m
@@ -214,6 +214,10 @@ BOOL isRegistrarDetached = NO;
     [configBuilder withGzip: [[configDict objectForKey:@"gzip"] boolValue]];
     [configBuilder
      withTrackLifecycleEvens:[[configDict objectForKey:@"trackLifecycleEvents"] boolValue]];
+    BOOL trackDeepLinks = [[configDict objectForKey:@"trackDeepLinks"] boolValue];
+    if (trackDeepLinks) {
+        [RSLogger logDebug:@"trackDeepLinks is not supported on Flutter iOS"];
+    }
     [configBuilder withRecordScreenViews:[[configDict objectForKey:@"recordScreenViews"] boolValue]];
     [configBuilder withSessionTimeoutMillis:[[configDict objectForKey:@"sessionTimeoutInMillis"]longValue]];
     [configBuilder withAutoSessionTracking:[[configDict objectForKey:@"autoSessionTracking"] boolValue]];


### PR DESCRIPTION
## Description of the change
This pull request adds support for configuring automatic deep link tracking in the Rudder plugin, specifically for Android, while ensuring the configuration is properly handled on both the Flutter and native sides. It introduces a new `trackDeepLinks` parameter to the configuration models, sets its default value, and updates tests to cover this new functionality. On iOS, the parameter is recognized but explicitly not supported, with a debug log added for clarity.

**Deep Link Tracking Configuration:**

* Added a new `trackDeepLinks` parameter to the `MobileConfig` class, including its constructor, getter, and default value (`true`), enabling control over automatic deep link tracking for Android. (`packages/plugins/rudder_plugin_interface/lib/src/models/rudder_mobile_config.dart`, [[1]](diffhunk://#diff-74722fda9a9e8ba16b8c4fbe6a6c8c5061548a77652df4e1415c8d26054ced46R38-R40) [[2]](diffhunk://#diff-74722fda9a9e8ba16b8c4fbe6a6c8c5061548a77652df4e1415c8d26054ced46L49-R53) [[3]](diffhunk://#diff-74722fda9a9e8ba16b8c4fbe6a6c8c5061548a77652df4e1415c8d26054ced46L60-R65) [[4]](diffhunk://#diff-74722fda9a9e8ba16b8c4fbe6a6c8c5061548a77652df4e1415c8d26054ced46R88-R89)
* Updated the configuration mapping in `RudderConfig` to include the `trackDeepLinks` value when building the mobile config map. (`packages/plugins/rudder_plugin_interface/lib/src/models/rudder_config.dart`, [packages/plugins/rudder_plugin_interface/lib/src/models/rudder_config.dartR120](diffhunk://#diff-4789316ef20c89292c5ff49e99144929c9a85ac3ac84d35c7b60000560f9f754R120))
* Added a constant for `TRACK_DEEP_LINKS` in `constants.dart` and set its default value to `true`. (`packages/plugins/rudder_plugin_interface/lib/src/constants.dart`, [packages/plugins/rudder_plugin_interface/lib/src/constants.dartR51-R53](diffhunk://#diff-140baab4604bfeb3ea99e3c25e6bffe3b6b42a69a1b36bf63c678f6c310d16a2R51-R53))

**Native Integration:**

* Passed the `trackDeepLinks` parameter from Flutter to the native Android SDK via the `RudderConfigParser`. (`packages/plugins/rudder_plugin_android/android/src/main/java/com/rudderstack/sdk/flutter/parsers/RudderConfigParser.java`, [packages/plugins/rudder_plugin_android/android/src/main/java/com/rudderstack/sdk/flutter/parsers/RudderConfigParser.javaR29](diffhunk://#diff-7ca89397bc6a529495c30a7d0e33fd70ead0321a7a0404d844c807aa608b9c01R29))
* On iOS, added logic to detect if `trackDeepLinks` is set, and log a debug message indicating that deep link tracking is not supported on Flutter iOS. (`packages/plugins/rudder_plugin_ios/ios/Classes/RudderSdkFlutterPlugin.m`, [packages/plugins/rudder_plugin_ios/ios/Classes/RudderSdkFlutterPlugin.mR217-R220](diffhunk://#diff-01daa6e79c0dc6a53b97c9bd0e319745bee7b8995835da645d433f712c386364R217-R220))

**Testing:**

* Added and expanded tests to verify that the `trackDeepLinks` parameter is correctly handled in the configuration, including its default value and getter behavior. (`packages/plugins/rudder_plugin_interface/test/src/models/rudder_config_test.dart`, [packages/plugins/rudder_plugin_interface/test/src/models/rudder_config_test.dartR194-R233](diffhunk://#diff-e5d617cc44831ef93c7b316c49a7df1c5a23ed768e250b533752b6e9b07778eaR194-R233))

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
