### PR TITLE
feat: update AppsFlyer integration version for iOS

### DIFF
--- a/packages/integrations/rudder_integration_appsflyer_flutter/ios/rudder_integration_appsflyer_flutter.podspec
+++ b/packages/integrations/rudder_integration_appsflyer_flutter/ios/rudder_integration_appsflyer_flutter.podspec
@@ -18,8 +18,8 @@ Pod::Spec.new do |s|
   s.static_framework = true
   s.dependency 'Flutter'
   s.dependency 'rudder_plugin_ios'
-  s.dependency 'Rudder-Appsflyer', '2.2.0'
-  s.platform = :ios, '9.0'
+  s.dependency 'Rudder-Appsflyer', '~> 2.8'
+  s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }


### PR DESCRIPTION
## Description
This PR updates the AppsFlyer iOS integration dependency version and minimum iOS deployment target for the Rudder-AppsFlyer Flutter integration package. The changes upgrade the AppsFlyer iOS SDK dependency from version `2.2.0` to `~> 2.8` and increase the minimum iOS deployment target from `9.0` to `13.0` to align with AppsFlyer's updated requirements.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
- Updated `Rudder-Appsflyer` dependency version from `2.2.0` to `~> 2.8` in the podspec file
- Increased minimum iOS platform requirement from `9.0` to `13.0`
- Modified `packages/integrations/rudder_integration_appsflyer_flutter/ios/rudder_integration_appsflyer_flutter.podspec`
- Changed dependency version specification to use flexible versioning (`~> 2.8`) for better compatibility

## Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation (if appropriate).
- [ ] I have ensured that my code follows the project's code style.
- [ ] I have checked for potential performance impacts and optimized if necessary.
- [ ] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
1. Create a new Flutter project that uses the AppsFlyer integration
2. Add the updated `rudder_integration_appsflyer_flutter` package as a dependency
3. Run `flutter pub get` to fetch dependencies
4. Build the iOS app to ensure the updated AppsFlyer SDK version integrates properly
5. Test basic AppsFlyer functionality (initialization, event tracking) on iOS 13.0+ devices
6. Verify that the app builds successfully with the new minimum iOS version requirement

## Breaking Changes
- **Minimum iOS Version**: The minimum supported iOS version has been increased from 9.0 to 13.0. Apps targeting iOS versions below 13.0 will no longer be supported.
- **AppsFlyer SDK Version**: Updated from 2.2.0 to ~> 2.8, which may introduce API changes or behavioral differences from the AppsFlyer SDK.

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
N/A - This is a dependency and configuration update with no UI changes.

## Additional Context
This update is necessary to:
- Take advantage of newer AppsFlyer iOS SDK features and improvements
- Maintain compatibility with the latest AppsFlyer releases
- Align with Apple's iOS version support lifecycle (iOS 9.0 is deprecated)
- Ensure security updates and bug fixes from the newer AppsFlyer SDK version

The flexible versioning (`~> 2.8`) allows for automatic patch and minor version updates while maintaining compatibility, following semantic versioning best practices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AppsFlyer SDK integration to the 2.8.x series, improving compatibility and stability on recent iOS versions.
  * Raised the minimum iOS deployment target to 13.0 to align with current platform requirements and dependencies. Apps targeting iOS 12 or earlier must increase their deployment target to build and run successfully.
  * Users on iOS 13+ should see no behavior changes, but benefit from improved underlying compatibility and maintenance updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->