### PR TITLE
Revert "feat: update AppsFlyer integration version for iOS"

### DIFF
--- a/packages/integrations/rudder_integration_appsflyer_flutter/ios/rudder_integration_appsflyer_flutter.podspec
+++ b/packages/integrations/rudder_integration_appsflyer_flutter/ios/rudder_integration_appsflyer_flutter.podspec
@@ -18,8 +18,8 @@ Pod::Spec.new do |s|
   s.static_framework = true
   s.dependency 'Flutter'
   s.dependency 'rudder_plugin_ios'
-  s.dependency 'Rudder-Appsflyer', '~> 2.8'
-  s.platform = :ios, '13.0'
+  s.dependency 'Rudder-Appsflyer', '2.2.0'
+  s.platform = :ios, '9.0'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }


### PR DESCRIPTION
Reverts rudderlabs/rudder-sdk-flutter#269

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Expanded iOS compatibility by lowering the minimum required version to iOS 9.0.

- Chores
  - Updated AppsFlyer dependency version for the Rudder integration to align with platform support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->