### PR TITLE
fix(android): prevent memory leaks in multi-engine scenarios

### DIFF
--- a/packages/plugins/rudder_plugin_android/pubspec.lock
+++ b/packages/plugins/rudder_plugin_android/pubspec.lock
@@ -145,7 +145,7 @@ packages:
       path: "../rudder_plugin_interface"
       relative: true
     source: path
-    version: "3.2.0"
+    version: "3.3.0"
   sky_engine:
     dependency: transitive
     description: flutter


### PR DESCRIPTION
## Purpose

Resolves critical memory leaks in the Flutter Android plugin caused by improper lifecycle callback management in multi-engine scenarios (e.g., when Firebase Cloud Messaging initialises a background Flutter engine). The previous implementation allowed multiple plugin instances to independently register ActivityLifecycleCallbacks, leading to:
- Memory leaks from accumulated callback registrations
- Null pointer exceptions when detached engines attempted to handle lifecycle events
- Duplicate event processing from multiple active callbacks

## Approach

Redesigned the ActivityLifeCycleManager to use a singleton pattern with ownership tracking:

**Registration Model:**
- First-wins registration: The first plugin instance to attach registers the lifecycle callbacks
- Subsequent plugin instances (e.g., FCM background engine) skip registration to prevent duplicates
- Plugin ownership tracking prevents unintended callback unregistration

**Lifecycle Event Routing:**
- When the SDK initialises, `setActivePlugin()` updates the singleton to route events to the initialised plugin
- Supports re-registration if a previous owner detaches before SDK initialisation
- Each plugin tracks whether it owns the lifecycle callbacks via `isLifecycleOwner` flag

**Clean-up:**
- Only the owning plugin unregisters callbacks during detachment
- Non-owning plugins safely detach without affecting active lifecycle monitoring

## Impact

**Breaking Changes:** None

**Behaviour Changes:**
- Multiple Flutter engines now safely coexist without callback conflicts
- Background FCM engines no longer interfere with foreground app lifecycle tracking

**Dependencies:** No new dependencies

## Additional Context

**Key Design Decision:**
Using a singleton pattern ensures only one set of callbacks is ever registered, regardless of how many Flutter engines are created. The `setActivePlugin()` method allows graceful handoff of event routing to whichever plugin actually initialises the SDK, supporting scenarios where the FCM background engine attaches first but the foreground engine initialises the SDK.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Introduced a centralized Android lifecycle manager with singleton registration for plugins.
  * Simplified plugin activation and unregistration flow during attach/detach.
  * Improved lifecycle coordination for more stable activity event handling and resource cleanup.
  * No changes to public-facing APIs or exported entities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->