### PR TITLE
chore: add DeepWiki badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # What is Rudder?
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/rudderlabs/rudder-sdk-flutter)
+
 **Short answer:**
 Rudder is an open-source Segment alternative written in Go, built for the enterprise.
 


### PR DESCRIPTION
## Description

Add a [DeepWiki](https://deepwiki.com) badge to the top of `README.md`. The badge links to the DeepWiki page for this repository, providing an easy entry point for AI-powered documentation and code exploration.

## Changes

- Added the "Ask DeepWiki" badge image and link to `README.md`, placed just below the main heading.

## Testing

- No functional code changes; visual verification that the badge renders correctly in the GitHub README.
