### PR TITLE
chore(vuln): suppress dangerous-triggers false positive (SEC-162)

### DIFF
--- a/.github/workflows/deploy-pubdev.yml
+++ b/.github/workflows/deploy-pubdev.yml
@@ -2,7 +2,7 @@ name: Deploy to pub.dev
 
 on:
   workflow_dispatch:
-  workflow_run:
+  workflow_run: # zizmor: ignore[dangerous-triggers]
     workflows: ["Publish new github release"]
     types:
       - completed


### PR DESCRIPTION
Suppresses zizmor dangerous-triggers false positive. This workflow_run triggers on release completion — no untrusted code checkout.