### PR TITLE
chore(vuln): replace GITHUB_ENV with GITHUB_OUTPUT in deploy-pubdev (SEC-162)

### DIFF
--- a/.github/workflows/deploy-pubdev.yml
+++ b/.github/workflows/deploy-pubdev.yml
@@ -59,12 +59,11 @@ jobs:
           melos publish --no-dry-run --yes
 
       - name: Get new version number
+        id: get-version
         run: |
           current_version=$(grep -A0 'version:' pubspec.yaml | tail -n1 | awk '{ print $2 }')
-          # zizmor: ignore[github-env]  # pubspec-derived version, not user-controlled
-          echo "CURRENT_VERSION_VALUE=$current_version" >> $GITHUB_ENV
-          # zizmor: ignore[github-env]  # date command output, not user-controlled
-          echo "DATE=$(date)" >> $GITHUB_ENV
+          echo "CURRENT_VERSION_VALUE=$current_version" >> "$GITHUB_OUTPUT"
+          echo "DATE=$(date)" >> "$GITHUB_OUTPUT"
 
       # - name: Send message to Slack channel
       #   id: slack
@@ -95,7 +94,7 @@ jobs:
       #             "type": "section",
       #             "text": {
       #               "type": "mrkdwn",
-      #               "text": "*Release: <${{ env.RELEASES_URL }}|Latest Packages>*\n${{ env.DATE }}"
+      #               "text": "*Release: <${{ env.RELEASES_URL }}|Latest Packages>*\n${{ steps.get-version.outputs.DATE }}"
       #             }
       #           }
       #         ]

--- a/.github/workflows/deploy-pubdev.yml
+++ b/.github/workflows/deploy-pubdev.yml
@@ -59,10 +59,11 @@ jobs:
           melos publish --no-dry-run --yes
 
       - name: Get new version number
+        id: get-version
         run: |
           current_version=$(grep -A0 'version:' pubspec.yaml | tail -n1 | awk '{ print $2 }')
-          echo "CURRENT_VERSION_VALUE=$current_version" >> $GITHUB_ENV
-          echo "DATE=$(date)" >> $GITHUB_ENV
+          echo "CURRENT_VERSION_VALUE=$current_version" >> "$GITHUB_OUTPUT"
+          echo "DATE=$(date)" >> "$GITHUB_OUTPUT"
 
       # - name: Send message to Slack channel
       #   id: slack
@@ -93,7 +94,7 @@ jobs:
       #             "type": "section",
       #             "text": {
       #               "type": "mrkdwn",
-      #               "text": "*Release: <${{ env.RELEASES_URL }}|Latest Packages>*\n${{ env.DATE }}"
+      #               "text": "*Release: <${{ env.RELEASES_URL }}|Latest Packages>*\n${{ steps.get-version.outputs.DATE }}"
       #             }
       #           }
       #         ]


### PR DESCRIPTION
## Summary
- Replace $GITHUB_ENV with $GITHUB_OUTPUT for CURRENT_VERSION_VALUE and DATE
- Update commented-out Slack step references to use step outputs
- Eliminates zizmor github-env findings

## Test plan
- [ ] Verify deploy-pubdev workflow runs correctly
- [ ] Confirm zizmor check passes