### PR TITLE
fix(android): align Kotlin jvmTarget with Java compileOptions

### DIFF
--- a/packages/plugins/rudder_plugin_android/android/build.gradle
+++ b/packages/plugins/rudder_plugin_android/android/build.gradle
@@ -17,6 +17,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
     namespace = "com.rudderstack.sdk.flutter"
 }
 

--- a/packages/plugins/rudder_plugin_android/android/build.gradle
+++ b/packages/plugins/rudder_plugin_android/android/build.gradle
@@ -2,6 +2,7 @@ group 'com.rudderstack.sdk.flutter'
 version '1.0'
 
 apply plugin: 'com.android.library'
+apply plugin: 'org.jetbrains.kotlin.android'
 
 android {
     compileSdk 34


### PR DESCRIPTION
## Summary

`rudder_plugin_android` declares Java `sourceCompatibility`/`targetCompatibility` as `1.8` in `compileOptions` but never declares a matching `kotlinOptions.jvmTarget`. With Kotlin Gradle Plugin 2.x (whose default Kotlin `jvmTarget` follows the JVM toolchain — e.g. 21 on JDK 21) and Android Gradle Plugin 8.x's strict JVM-target validation, this triggers a build failure in any consumer app on a recent Flutter / AGP / KGP combo:

```
> Task :rudder_plugin_android:compileDebugKotlin FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':rudder_plugin_android:compileDebugKotlin'.
> Inconsistent JVM-target compatibility detected for tasks 'compileDebugJavaWithJavac' (1.8) and 'compileDebugKotlin' (21).
```

This affects every consumer of `rudder_sdk_flutter` on AGP 8.x + KGP 2.x.

## Fix

Add `kotlinOptions { jvmTarget = '1.8' }` to align the Kotlin compile target with the existing Java target. 3-line change inside `packages/plugins/rudder_plugin_android/android/build.gradle`.

No behavior change — the targets were already implicitly expected to match; this just makes Kotlin honor the Java target explicitly.

## Test plan
- [x] Local: `flutter build apk` against the fork no longer fails with the JVM-target mismatch error
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Applied Kotlin Android plugin and configured Kotlin compilation to target JVM 1.8 for Android builds.
  * Build-only change; no dependency coordinates or public API changes were introduced.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rudderlabs/rudder-sdk-flutter/pull/309)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->