### PR TITLE
chore(codeowners): set sdk_team as code owners

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: 'BUG : <Title>'
 labels: bug, open source
-assignees: '@rudderlabs/sdk-flutter'
+assignees: []
 ---
 
 **Describe the bug**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,7 @@ name: Feature request
 about: Suggest an idea for this project
 title: 'Feature Request: <Title>'
 labels: open source
-assignees: itsdebs
+assignees: []
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -106,7 +106,6 @@ jobs:
           github_token: ${{ steps.generate-token.outputs.token }}
           pr_title: 'chore(release): pulling main into develop post release v${{ steps.extract-version.outputs.release_version }}'
           pr_body: ':crown: *An automated PR*'
-          pr_reviewer: '@rudderlabs/sdk-flutter'
 
       - name: Delete hotfix release branch
         uses: koj-co/delete-merged-action@63a03c35810a8a7d4840d18793c0f68ff8b59450 # master

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @rudderlabs/sdk-flutter
+* @rudderlabs/sdk_team


### PR DESCRIPTION
## Summary

Replaces the repo's code owners with the whole SDK team (`@rudderlabs/sdk_team`) so any team member's review can unblock chore PRs (Dependabot merges, CI fixes) instead of waiting on the `sdk-flutter` sub-team. Part of the SDK-5102 rollout across SDK repos; resolves SDK-5110.

## Changes

- `CODEOWNERS` (repo root): default owner changed from `@rudderlabs/sdk-flutter` to `@rudderlabs/sdk_team`.
- `.github/ISSUE_TEMPLATE/bug_report.md` and `.github/ISSUE_TEMPLATE/feature_request.md`: default assignees replaced with an empty list (were `@rudderlabs/sdk-flutter` and `itsdebs`) — GitHub issue assignees only accept individual users, so a team can't be set here; new issues get routed by on-call triage instead.
- `.github/workflows/publish-new-release.yml`: dropped the hardcoded `pr_reviewer` from the automated main→develop merge-back PR — the action's `pr_reviewer` input only accepts usernames (a team handle is a no-op), and CODEOWNERS auto-requests the team's review on that PR anyway. Keeps the workflow owner-agnostic for future ownership changes.

## Testing

- Verified `@rudderlabs/sdk_team` already has write access on this repo, so GitHub honors it as code owner as soon as this merges — no access changes needed.
- Post-merge check: the next PR should auto-request review from `sdk_team`, and any member's approval should satisfy the code-owner requirement.

## Screenshots

No UI changes in this PR.

## Notes

No breaking changes or migration steps required. Review-routing change only — the release workflow's behavior is unchanged apart from reviewer assignment now coming from CODEOWNERS.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated bug report and feature request templates so new submissions are not automatically assigned to a specific individual.
  * Updated code ownership routing to direct relevant review requests to the current SDK team.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->