### PR TITLE
fix(ci): repair the release workflows after the App token migration

### DIFF
--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -137,9 +137,19 @@ jobs:
           # `melos version` has already committed the version bumps and changelogs by
           # this point, so the index is empty and diffing it would yield nothing.
           # Diff against the branch point instead to capture every released file.
-          CHANGED_FILES=$(git diff --name-only "$BASE_SHA" HEAD | tr '\n' ' ')
-          echo "changed_files=$CHANGED_FILES" >> $GITHUB_OUTPUT
-          echo "Files to publish: $CHANGED_FILES"
+          #
+          # The signed-commit action takes a newline-separated list, so the value has to
+          # keep its newlines -- collapsing it onto one line makes `git add` treat the
+          # whole list as a single pathspec and nothing gets committed. Multi-line values
+          # need a heredoc delimiter to survive GITHUB_OUTPUT.
+          {
+            echo "changed_files<<CHANGED_FILES_EOF"
+            git diff --name-only "$BASE_SHA" HEAD
+            echo "CHANGED_FILES_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Files to publish:"
+          git diff --name-only "$BASE_SHA" HEAD
           git for-each-ref refs/tags
 
       - name: Push signed version changes

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -102,9 +102,8 @@ jobs:
             -f ref="refs/heads/${BRANCH_NAME}" \
             -f sha="$BASE_SHA"
 
-          # `melos version` runs `git pull --tags` internally, which fails unless the
-          # current branch has tracking information. Creating the ref over the API does
-          # not set it on the local branch, so wire it up explicitly.
+          # `melos version` runs `git pull --tags`, which needs branch tracking.
+          # Creating the ref over the API does not set it.
           git fetch origin "$BRANCH_NAME"
           git branch --set-upstream-to="origin/${BRANCH_NAME}" "$BRANCH_NAME"
 
@@ -125,23 +124,17 @@ jobs:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           BASE_SHA: ${{ steps.create-branch.outputs.base_sha }}
         run: |
-          # Capture the tags melos created before rewinding below, so they can be
-          # re-pointed at the signed commit once it exists.
+          # Capture melos's tags before the rewind below moves HEAD off them.
           PACKAGE_TAGS=$(git tag --points-at HEAD | tr '\n' ' ')
           echo "package_tags=$PACKAGE_TAGS" >> $GITHUB_OUTPUT
           echo "Package tags: $PACKAGE_TAGS"
 
-          # Stage anything melos left behind in the working tree, then rewind to the
-          # branch point keeping the tree in the index. The signed-commit action builds
-          # its commit from *staged* changes (`git status -suno --porcelain`), and melos
-          # has already committed everything, so without this it detects nothing to
-          # commit and the release branch ends up with no version bumps.
+          # The signed-commit action commits *staged* changes, and melos has already
+          # committed them. Rewind so the release tree sits in the index instead.
           git add .
           git reset --soft "$BASE_SHA"
 
-          # The action reads `files` as a multi-line input, so the value must keep its
-          # newlines -- a space-joined line is treated as one pathspec and matches
-          # nothing. Multi-line values need a heredoc delimiter to survive GITHUB_OUTPUT.
+          # `files` is a multi-line input, so the newlines have to survive GITHUB_OUTPUT.
           {
             echo "changed_files<<CHANGED_FILES_EOF"
             git diff --cached --name-only
@@ -167,10 +160,8 @@ jobs:
           COMMIT_SHA: ${{ steps.push-changes.outputs.commit-sha }}
           PACKAGE_TAGS: ${{ steps.prepare-changes.outputs.package_tags }}
         run: |
-          # `melos version` tags a local commit, but the signed commit pushed above is a
-          # different object. Point each package tag at the pushed commit so they remain
-          # ancestors of main once the release PR merges -- melos reads these tags to
-          # work out what changed in the next release.
+          # melos tagged a local commit, not the signed one pushed above. These tags must
+          # stay ancestors of main -- melos reads them to scope the next release.
           for tag in $PACKAGE_TAGS; do
             echo "Tagging ${tag} -> ${COMMIT_SHA}"
             gh api "repos/${{ github.repository }}/git/refs" \

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -91,14 +91,24 @@ jobs:
           echo "NEW_VERSION_VALUE=$new_version" >> $GITHUB_ENV
 
       - name: Create release branch via GitHub API
+        id: create-branch
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          BRANCH_NAME: ${{ steps.create-release.outputs.branch_name }}
         run: |
           BASE_SHA=$(git rev-parse HEAD)
           gh api repos/${{ github.repository }}/git/refs \
             --method POST \
-            -f ref="refs/heads/${{ steps.create-release.outputs.branch_name }}" \
+            -f ref="refs/heads/${BRANCH_NAME}" \
             -f sha="$BASE_SHA"
+
+          # `melos version` runs `git pull --tags` internally, which fails unless the
+          # current branch has tracking information. Creating the ref over the API does
+          # not set it on the local branch, so wire it up explicitly.
+          git fetch origin "$BRANCH_NAME"
+          git branch --set-upstream-to="origin/${BRANCH_NAME}" "$BRANCH_NAME"
+
+          echo "base_sha=$BASE_SHA" >> $GITHUB_OUTPUT
 
       - name: Update changelog & bump version
         id: finish-release
@@ -113,14 +123,27 @@ jobs:
         id: prepare-changes
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          BASE_SHA: ${{ steps.create-branch.outputs.base_sha }}
         run: |
+          # Capture the tags melos just created before amending: `git commit --amend`
+          # rewrites the commit, leaving the tags pointing at the original object.
+          PACKAGE_TAGS=$(git tag --points-at HEAD | tr '\n' ' ')
+          echo "package_tags=$PACKAGE_TAGS" >> $GITHUB_OUTPUT
+          echo "Package tags: $PACKAGE_TAGS"
+
           git add .
-          CHANGED_FILES=$(git diff --cached --name-only | tr '\n' ' ')
-          echo "changed_files=$CHANGED_FILES" >> $GITHUB_OUTPUT
           git commit --amend --no-edit
+
+          # `melos version` has already committed the version bumps and changelogs by
+          # this point, so the index is empty and diffing it would yield nothing.
+          # Diff against the branch point instead to capture every released file.
+          CHANGED_FILES=$(git diff --name-only "$BASE_SHA" HEAD | tr '\n' ' ')
+          echo "changed_files=$CHANGED_FILES" >> $GITHUB_OUTPUT
+          echo "Files to publish: $CHANGED_FILES"
           git for-each-ref refs/tags
 
       - name: Push signed version changes
+        id: push-changes
         uses: ryancyq/github-signed-commit@e9f3b28c80da7be66d24b8f501a5abe82a6b855f # v1.2.0
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
@@ -128,6 +151,24 @@ jobs:
           branch-name: ${{ steps.create-release.outputs.branch_name }}
           commit-message: "chore: version bump to ${{ steps.create-release.outputs.new_version }}"
           files: ${{ steps.prepare-changes.outputs.changed_files }}
+
+      - name: Push package tags
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          COMMIT_SHA: ${{ steps.push-changes.outputs.commit-sha }}
+          PACKAGE_TAGS: ${{ steps.prepare-changes.outputs.package_tags }}
+        run: |
+          # `melos version` tags a local commit, but the signed commit pushed above is a
+          # different object. Point each package tag at the pushed commit so they remain
+          # ancestors of main once the release PR merges -- melos reads these tags to
+          # work out what changed in the next release.
+          for tag in $PACKAGE_TAGS; do
+            echo "Tagging ${tag} -> ${COMMIT_SHA}"
+            gh api "repos/${{ github.repository }}/git/refs" \
+              --method POST \
+              -f ref="refs/tags/${tag}" \
+              -f sha="$COMMIT_SHA"
+          done
 
       - name: Create pull request into main
         uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 #v2

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -125,32 +125,31 @@ jobs:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           BASE_SHA: ${{ steps.create-branch.outputs.base_sha }}
         run: |
-          # Capture the tags melos just created before amending: `git commit --amend`
-          # rewrites the commit, leaving the tags pointing at the original object.
+          # Capture the tags melos created before rewinding below, so they can be
+          # re-pointed at the signed commit once it exists.
           PACKAGE_TAGS=$(git tag --points-at HEAD | tr '\n' ' ')
           echo "package_tags=$PACKAGE_TAGS" >> $GITHUB_OUTPUT
           echo "Package tags: $PACKAGE_TAGS"
 
+          # Stage anything melos left behind in the working tree, then rewind to the
+          # branch point keeping the tree in the index. The signed-commit action builds
+          # its commit from *staged* changes (`git status -suno --porcelain`), and melos
+          # has already committed everything, so without this it detects nothing to
+          # commit and the release branch ends up with no version bumps.
           git add .
-          git commit --amend --no-edit
+          git reset --soft "$BASE_SHA"
 
-          # `melos version` has already committed the version bumps and changelogs by
-          # this point, so the index is empty and diffing it would yield nothing.
-          # Diff against the branch point instead to capture every released file.
-          #
-          # The signed-commit action takes a newline-separated list, so the value has to
-          # keep its newlines -- collapsing it onto one line makes `git add` treat the
-          # whole list as a single pathspec and nothing gets committed. Multi-line values
-          # need a heredoc delimiter to survive GITHUB_OUTPUT.
+          # The action reads `files` as a multi-line input, so the value must keep its
+          # newlines -- a space-joined line is treated as one pathspec and matches
+          # nothing. Multi-line values need a heredoc delimiter to survive GITHUB_OUTPUT.
           {
             echo "changed_files<<CHANGED_FILES_EOF"
-            git diff --name-only "$BASE_SHA" HEAD
+            git diff --cached --name-only
             echo "CHANGED_FILES_EOF"
           } >> "$GITHUB_OUTPUT"
 
           echo "Files to publish:"
-          git diff --name-only "$BASE_SHA" HEAD
-          git for-each-ref refs/tags
+          git diff --cached --name-only
 
       - name: Push signed version changes
         id: push-changes

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -96,15 +96,12 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
-          # The tag is created remotely over the API by the step above, i.e. after checkout
-          # fetched tags. conventional-github-releaser picks its target from *local* tags
-          # (via git-semver-tags), so without this it targets the previous release and 422s.
+          # The step above created the tag remotely, after checkout fetched tags. The
+          # releaser reads *local* tags, so without this it targets the previous release.
           git fetch origin --tags --force
 
-          # Its transform matches a semver anywhere in the git decoration, so a branch ref
-          # such as `origin/release/5.3.3` gets mistaken for a tag. That yields a spurious
-          # `5.3.3` release holding the notes while the real `v5.3.3` is published empty.
-          # Hiding those refs from `git log --decorate` keeps tags the only match.
+          # The releaser matches a semver anywhere in the decoration, so a branch ref like
+          # `origin/release/5.3.3` reads as a tag and steals the release notes.
           git config log.excludeDecoration 'refs/remotes/origin/release/*'
           git config --add log.excludeDecoration 'refs/remotes/origin/hotfix-release/*'
 
@@ -126,10 +123,8 @@ jobs:
         with:
           branches: 'hotfix-release/*'
         env:
-          # This action lists PRs before deleting, so it needs pull-requests read and
-          # contents write. The job pins GITHUB_TOKEN to `contents: read`, and a job-level
-          # permissions block zeroes out everything it omits -- leaving pull-requests at
-          # none, which 403s. Use the app token, as every other privileged step here does.
+          # Lists PRs before deleting, so it needs pull-requests read + contents write.
+          # GITHUB_TOKEN has neither: the job pins it to `contents: read`.
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
 
       - name: Delete release branch

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -96,6 +96,18 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
+          # The tag is created remotely over the API by the step above, i.e. after checkout
+          # fetched tags. conventional-github-releaser picks its target from *local* tags
+          # (via git-semver-tags), so without this it targets the previous release and 422s.
+          git fetch origin --tags --force
+
+          # Its transform matches a semver anywhere in the git decoration, so a branch ref
+          # such as `origin/release/5.3.3` gets mistaken for a tag. That yields a spurious
+          # `5.3.3` release holding the notes while the real `v5.3.3` is published empty.
+          # Hiding those refs from `git log --decorate` keeps tags the only match.
+          git config log.excludeDecoration 'refs/remotes/origin/release/*'
+          git config --add log.excludeDecoration 'refs/remotes/origin/hotfix-release/*'
+
           DEBUG=conventional-github-releaser npx conventional-github-releaser -p angular --config github-release.config.js
 
       - name: Create pull request into develop
@@ -114,7 +126,11 @@ jobs:
         with:
           branches: 'hotfix-release/*'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # This action lists PRs before deleting, so it needs pull-requests read and
+          # contents write. The job pins GITHUB_TOKEN to `contents: read`, and a job-level
+          # permissions block zeroes out everything it omits -- leaving pull-requests at
+          # none, which 403s. Use the app token, as every other privileged step here does.
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
 
       - name: Delete release branch
         uses: koj-co/delete-merged-action@63a03c35810a8a7d4840d18793c0f68ff8b59450 # master
@@ -122,7 +138,7 @@ jobs:
         with:
           branches: 'release/*'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
 
       # - name: Send message to Slack channel
       #   id: slack


### PR DESCRIPTION
## Description

The `Draft new release` workflow is currently broken and will fail if run. The SEC-58 migration (#287) rewrote it to use a GitHub App token and to create the release branch over the GitHub API instead of `git push --set-upstream`. That rewrite landed on `develop` on 18 June, but no release has been cut since 29 April (`v5.3.2`) — so the new code has never actually executed.

Running the workflow's steps locally against melos 6.3.3 (the version CI pins) surfaced three defects. This PR fixes all three, so `draft-new-release` produces a correct release branch again.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details

**1. `melos version` aborts the workflow (blocking)**

`melos version` runs `git pull --tags` internally, which requires the current branch to have tracking information. The old workflow supplied it via `git push --set-upstream origin "$branch_name"`; that line was removed in favour of creating the ref over the API, which does not set tracking on the *local* branch. The workflow therefore dies at *Update changelog & bump version*:

```
Melos: Failed executing a git command:
  There is no tracking information for the current branch.
  Command: git pull --tags
```

Fixed by fetching the newly created ref and calling `git branch --set-upstream-to` after the API step.

**2. `changed_files` never contains the version bumps**

`changed_files` was computed as `git add . && git diff --cached --name-only`, but that runs *after* `melos version` has already committed the bumps and changelogs — so the index is empty and the diff resolves to a stray file (or nothing). The signed commit would then push a release branch with **no version changes at all**, producing an empty release PR.

Fixed by diffing against the branch point (`$BASE_SHA..HEAD`) after the amend, which captures all 26 released files (root + per-package `pubspec.yaml` / `CHANGELOG.md`, and `sonar-project.properties`).

**3. Per-package tags are never pushed**

`git push origin --tags` and `git push --follow-tags` were dropped, so the 12 tags `melos version` creates (`rudder_integration_braze_flutter-v2.7.0`, `rudder_sdk_flutter-v3.3.3`, …) never reach the remote. `publish-new-release` only pushes the `vX.Y.Z` monorepo tag. Melos reads these per-package tags to work out what changed in the *next* release, so their absence would cause subsequent releases to mis-compute versions.

Fixed with a new *Push package tags* step that recreates each tag over the API against the signed commit. Two subtleties handled:
- The tag list is captured *before* `git commit --amend`, since the amend rewrites the commit and leaves melos's tags pointing at the original object (`git tag --points-at HEAD` returns nothing afterwards).
- Tags are pointed at the signed commit's SHA (via the action's `commit-sha` output), not the local commit, so they remain ancestors of `main` once the release PR merges.

**Hardening**

`branch_name` and `base_sha` now travel through `env:` instead of inline `${{ }}` interpolation inside `run:` blocks, consistent with the SEC-343 hardening applied elsewhere.

## Does this maintain the intent of SEC-58?

Yes. All three fixes preserve the migration's goals:

| Change | PAT removed | Commits stay signed |
|---|---|---|
| `--set-upstream-to` | Uses the App token; `git fetch` + a local config change only, no commit pushed | Unaffected |
| `changed_files` | Unaffected | Commit is still created server-side by `ryancyq/github-signed-commit` |
| Push package tags | Uses `gh api` with the App token — does **not** restore `git push --tags` | Tags point at the action's signed commit |

Notably, the tag step does not roll back to the pre-SEC-58 behaviour: previously melos's locally-created annotated tag objects were pushed unsigned via PAT. This creates lightweight refs server-side with the App token, pointing at the signed commit — strictly tighter than before.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works. — N/A for workflow YAML; verified by simulating the workflow locally (see *How to test?*)
- [ ] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required). — N/A, CI-only change

## How to test?

These changes were validated by replaying the workflow's exact steps locally against a bare git remote (standing in for the GitHub API ref creation), using melos `6.3.3` to match CI:

| Check | Before | After |
|---|---|---|
| `melos version -a --yes` | exit `255` — *no tracking information* | exit `0` |
| `changed_files` | 1 stray file (`example/pubspec.lock`) | 26 files, incl. all pubspecs/changelogs + `sonar-project.properties` |
| `package_tags` | 0 (never pushed) | 12, incl. `rudder_integration_braze_flutter-v2.7.0` |

With #312 merged, the run resolves to monorepo `5.4.0` and braze `2.7.0`, which matches the intended `feat` → minor bump.

**Recommended before the next real release:** given this machinery has never run end-to-end, dry-run `Draft new release` from a throwaway branch and confirm the release branch carries the version bumps and that the 12 package tags appear, rather than trusting the first live release.

## Breaking Changes

None. CI-only change; no SDK or public API surface is touched.

## Maintainers Checklist

- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)

N/A

## Additional Context

- Out of scope: `Deploy to pub.dev` is also broken, but for an unrelated and pre-existing reason — pub.dev rejects OIDC tokens originating from a `workflow_run` event (*"publishing is only allowed from 'push' or 'workflow_dispatch' events"*). It has failed on every run since 2025-08-11, including all six successful releases; publishing is done manually per the Notion runbook. This PR does not change that.
- `publish-new-release.yml` calls the signed-commit action with `files: ''`. It has likewise never run since the SEC-58 rewrite, so it is untested and may need a follow-up.


---

## Verified against live CI

Dispatched on a throwaway `hotfix/ci-test-release` branch (the job guard allows `hotfix/*`, so this runs the real workflow without merging first). Three runs; the first two exposed defects that **local simulation could not catch**, because they live inside the signed-commit action rather than in git or melos:

| Run | Outcome |
|---|---|
| [29393146876](https://github.com/rudderlabs/rudder-sdk-flutter/actions/runs/29393146876) | `melos version` **passed** (blocker fixed) — but `git add` got all 26 paths as a single pathspec: `fatal: pathspec 'CHANGELOG.md example/pubspec.lock ...' did not match any files` |
| [29393425422](https://github.com/rudderlabs/rudder-sdk-flutter/actions/runs/29393425422) | pathspec fixed, but still `No files changes` — the action builds its commit from *staged* changes, and melos had already committed them |
| [29393676624](https://github.com/rudderlabs/rudder-sdk-flutter/actions/runs/29393676624) | **All 18 steps green** |

This means SEC-343's `files:` change was independently broken: even with the tracking fix alone, the release branch would still have carried **zero version bumps**.

Final run produced:

- **26 files** on the release branch with real bumps (root `5.3.2 → 5.3.3`, braze `2.6.2 → 2.6.3`)
- **12/12 package tags**, all pointing at the release commit `714c9af`
- Commit `verified: true`, authored by `rudderstack-github-actions[bot]` — signing intact

Nothing was published: the release PR was closed unmerged, so `publish-new-release` **skipped** (`merged == false`) and `deploy-pubdev` **skipped** (upstream conclusion wasn't `success`). Latest release is still `v5.3.2`. All test tags/branches deleted.

> Note: the run computed `5.3.3` rather than `5.4.0` because this branch is off `develop`, which does not yet include #312.


---

# `publish-new-release.yml` — verified in a sandbox

Because this workflow only fires when a release PR is **merged into `main`**, it cannot be dry-run in this repo. It was instead verified end-to-end in a throwaway sandbox (`vgupta98/flutter-release-ci-sandbox`) seeded with real history, a real `v5.3.2` release as the precondition, and the same action SHAs — by actually merging a `release/5.3.3` PR.

## Bug 1 — no release is created, and the job aborts

Merging produced tag `v5.3.3` but **no release for it**. The step hard-fails:

```
conventional-github-releaser posting { name: 'v5.3.2', tag_name: 'v5.3.2' }
GitHubError: Validation Failed (422)
##[error]Process completed with exit code 1
```

`ryancyq/github-signed-commit` creates the tag **remotely over GraphQL**, after `actions/checkout` has already fetched tags. `conventional-github-releaser` selects its target from **local** tags via `git-semver-tags` (`git log --decorate`), so the newest tag it sees is always the *previous* release — which already has a release, hence the 422. Before SEC-58 the tag was created locally with `git tag -a`, so it was visible.

Because the step exits non-zero, the **develop back-merge PR and the release-branch cleanup never run** — the release half-completes.

## Bug 2 — empty and duplicate releases (pre-existing, already live)

`git fetch --tags` alone is **not sufficient**. It fixes the 422 but yields:

```
posting { body: '\n\n\n',         tag_name: 'v5.3.4' }   ← empty
posting { body: '...feat/fix...', tag_name: '5.3.4'  }   ← stray tag steals the notes
```

The releaser's `transform` matches a semver **anywhere in the git decoration**, so the branch ref `origin/release/5.3.4` is mistaken for a tag.

This predates SEC-58 and is **visible in this repo's published releases today**:

- `v5.3.2` notes are empty (body is literally `"\n\n\n"`)
- 29 of the last 100 releases have empty notes
- `v5.2.0`, `v5.0.0`, `v4.7.0` each appear **twice** (one empty, one with notes)
- 14 stray non-`v` tags exist (`3.0.0`…`4.3.0`); `4.3.0` and `v4.3.0` point at **different commits**

This is the cause of the Release Process runbook's long-standing note: *"Will create two GitHub release. (This needs to be fixed)"*.

Excluding those refs from the decoration leaves tags as the only match. Verified: one release, correct tag, correct notes.

## Bug 3 — branch cleanup 403s

`koj-co/delete-merged-action` ran on `secrets.GITHUB_TOKEN`, which the job pins to `contents: read`. A job-level `permissions:` block **also zeroes out everything it omits**, so `pull-requests` sat at `none` and the action 403'd while *listing PRs* — before `contents` was ever reached:

```
x-accepted-github-permissions: 'pull_requests=read; contents=read'
##[error]Resource not accessible by integration   (403)
```

Sandbox matrix:

| `contents` | `pull-requests` | Result |
|---|---|---|
| `read` | none | **403 hard fail — the current config** |
| `read` | `read` | job "success", branch **not deleted** (error swallowed, exit 0) |
| `write` | `read` | deleted correctly |

Routing these through the app token (which already requests `contents: write` + `pull-requests: write`) keeps `GITHUB_TOKEN` least-privilege, consistent with SEC-58.

## Verification status

| Fix | Status |
|---|---|
| `git fetch --tags` + `log.excludeDecoration` | **Runtime-verified** in sandbox — correct single release with correct notes |
| Delete steps → app token | **Reasoned, not runtime-verified** — a personal sandbox cannot mint the org app token. The verified-equivalent was job-level `contents: write` + `pull-requests: read`; the app token achieves the same permissions without widening `GITHUB_TOKEN` |

Sandbox substituted `secrets.GITHUB_TOKEN` for the app token; action SHAs, step order, `files: ''`, `branch-name: main`, the releaser invocation and `github-release.config.js` were kept byte-identical.

## Follow-ups (deliberately not in this PR)

- The 14 stray tags and 29 empty releases already published are **not** cleaned up here — that is data repair, not a workflow fix.
- `node-version: 16` is EOL.
- The workflow-level `permissions:` block (lines 10-12) is dead — fully overridden by the job-level block.
