### PR TITLE
fix: bump minimum iOS SDK version to 1.32.2

### DIFF
--- a/packages/plugins/rudder_plugin_ios/ios/rudder_plugin_ios.podspec
+++ b/packages/plugins/rudder_plugin_ios/ios/rudder_plugin_ios.podspec
@@ -12,7 +12,7 @@ RudderStack flutter SDK ios plugin project
   s.source_files = 'rudder_plugin_ios/Sources/rudder_plugin_ios/**/*'
   s.public_header_files = 'rudder_plugin_ios/Sources/rudder_plugin_ios/include/**/*.h'
   s.dependency 'Flutter'
-  s.dependency "Rudder", '>= 1.31.1', '< 2.0.0'
+  s.dependency "Rudder", '>= 1.32.2', '< 2.0.0'
   s.platform = :ios, '12.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/packages/plugins/rudder_plugin_ios/ios/rudder_plugin_ios/Package.swift
+++ b/packages/plugins/rudder_plugin_ios/ios/rudder_plugin_ios/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "rudder-plugin-ios", targets: ["rudder_plugin_ios"])
     ],
     dependencies: [
-        .package(url: "https://github.com/rudderlabs/rudder-sdk-ios.git", from: "1.31.1")
+        .package(url: "https://github.com/rudderlabs/rudder-sdk-ios.git", from: "1.32.2")
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Description
Raises the minimum `Rudder` iOS pod version that `rudder_plugin_ios` depends on from `1.31.1` to `1.32.2`. `Rudder` 1.32.2 contains the iOS persistence-threading fix that moves `NSUserDefaults`/plist disk writes off the main thread, resolving the App Hang / Watchdog Termination observed during SDK initialization. Bumping the dependency floor guarantees Flutter consumers pull a native iOS SDK that includes this fix.

The dependency constraint stays within the same major range (`< 2.0.0`); only the lower bound moves.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
- `packages/plugins/rudder_plugin_ios/ios/rudder_plugin_ios.podspec`: bumped the `Rudder` dependency from `>= 1.31.1, < 2.0.0` to `>= 1.32.2, < 2.0.0`.

## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

> Note: the fix itself and its unit/E2E test coverage live in `rudder-sdk-ios` (v1.32.2). This PR only propagates the version. Verified by running the example app on iOS against a live source (see "How to test?").

## How to test?
1. Point the example app at the local monorepo `rudder_plugin_ios` (dependency overrides), then `pod install` in `example/ios` — CocoaPods must resolve `Rudder` to `1.32.2`.
2. Run the example on an iOS simulator with a valid write key + data plane URL.
3. Initialize the SDK and send `identify` / `track` / `screen` events.
4. Confirm the SDK initializes without crashing and the events are flushed to the data plane (HTTP `200`).

## Breaking Changes
None. The constraint remains within the `1.x` major range; consumers on `1.32.2+` are unaffected, and those below are upgraded to the fixed version.

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
N/A

## Additional Context
Propagates the iOS App Hang / persistence fix (`rudder-sdk-ios` v1.32.2) to the Flutter SDK. Part of the SDK-5130 customer escalation follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum supported iOS Rudder SDK version to 1.32.2.
  * The maximum supported version remains below 2.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->