### PR TITLE
fix: bump minimum Android SDK version to 1.28.1

### DIFF
--- a/packages/plugins/rudder_plugin_android/android/build.gradle
+++ b/packages/plugins/rudder_plugin_android/android/build.gradle
@@ -25,6 +25,6 @@ android {
 }
 
 dependencies {
-    implementation 'com.rudderstack.android.sdk:core:[1.24.0, 2.0.0)'
+    implementation 'com.rudderstack.android.sdk:core:[1.28.1, 2.0.0)'
     implementation 'com.google.code.gson:gson:2.8.6'
 }


### PR DESCRIPTION
## Description
Raises the floor of the `com.rudderstack.android.sdk:core` dependency in `rudder_plugin_android` from `1.24.0` to `1.28.1`, so the scoped-`Serializable` ProGuard fix (released in Android core `1.28.1`) reaches Flutter consumers.

The Android core previously shipped an app-wide consumer ProGuard rule (`-keep class * implements java.io.Serializable { *; }`) that disabled R8 optimization on every `Serializable` class in the host app. Core `1.28.1` replaces it with an explicit, narrowly-scoped keep list covering only the object graphs the SDK actually persists via `ObjectOutputStream`. Bumping the plugin floor is required because an Android-core fix does not reach Flutter automatically — the version range is not relied upon in practice; each core fix needs an explicit floor bump plus a Flutter release.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
- `packages/plugins/rudder_plugin_android/android/build.gradle`: bump `com.rudderstack.android.sdk:core` dependency floor from `[1.24.0, 2.0.0)` to `[1.28.1, 2.0.0)`.

## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
1. Build a Flutter app that depends on `rudder_plugin_android` with R8/minification enabled.
2. Confirm the resolved `com.rudderstack.android.sdk:core` artifact is `>= 1.28.1`.
3. Verify the previously over-broad `-keep class * implements java.io.Serializable` rule is no longer applied app-wide, while SDK persistence (source config / flush config) still deserializes correctly across an SDK upgrade.

The underlying fix was validated in Android core (PR rudderlabs/rudder-sdk-android#555): an emulator upgrade test (config written by the old build still deserializes on the new build) plus a real minified sample-app run sending events successfully.

## Breaking Changes
None. Consumers already on core `>= 1.28.1` are unaffected; the change only raises the minimum.

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
N/A

## Additional Context
- Linear: SDK-5197 (sub-issue of SDK-5136, CloudWalk ProGuard blocker).
- Android core fix: SDK-5190 / rudderlabs/rudder-sdk-android#555, released as core `1.28.1`.
- A Flutter release (plugin + `rudder_sdk_flutter`) to pub.dev is required after this merge for the fix to reach customers.
