### PR TITLE
fix: publish Android ProGuard scoping fix to pub.dev

### DIFF
--- a/packages/plugins/rudder_plugin_android/android/build.gradle
+++ b/packages/plugins/rudder_plugin_android/android/build.gradle
@@ -25,6 +25,9 @@ android {
 }
 
 dependencies {
+    // Floor pinned to 1.28.1: this core version scopes the Serializable ProGuard
+    // consumer rule to the persisted config graphs, restoring R8 optimization in
+    // host apps (previously the rule kept every Serializable class app-wide).
     implementation 'com.rudderstack.android.sdk:core:[1.28.1, 2.0.0)'
     implementation 'com.google.code.gson:gson:2.8.6'
 }


### PR DESCRIPTION
## Description
Adds a versionable `fix(android)` commit so the already-merged Android core floor bump (`com.rudderstack.android.sdk:core >= 1.28.1`, SDK-5197) actually ships to pub.dev.

The original bump (#320) landed on `develop` as a `chore(rudder_plugin_android)` commit. Melos only versions `feat`/`fix`/breaking commits, so `chore` produces no version bump — meaning `rudder_plugin_android` would not be republished and the scoped-`Serializable` ProGuard fix (from core `1.28.1`) would never reach Flutter consumers. This PR annotates the `build.gradle` dependency with a `fix(android)` commit that touches the `rudder_plugin_android` package, causing melos to patch-bump and publish it.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
- `packages/plugins/rudder_plugin_android/android/build.gradle`: add a comment above the `core` dependency documenting why the floor is pinned to `1.28.1`. The functional floor (`[1.28.1, 2.0.0)`) is unchanged from #320 — this commit exists to give melos a versionable change on the package.

## Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
1. Merge this PR (single commit; keep the `fix(android):` message so melos picks it up).
2. Run `Draft new release` — confirm `rudder_plugin_android` receives a patch bump (3.2.2 → 3.2.3) and appears in the release with a `**FIX**(android): …` changelog entry.
3. After release, confirm the new `rudder_plugin_android` version on pub.dev resolves `core >= 1.28.1`. The fix itself was already validated on-device: a minified Flutter release build inits, sends events, and returns a correctly-keyed `getRudderContext()` under R8.

## Breaking Changes
None. The dependency constraint is unchanged; this only ensures the already-intended floor is published.

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
N/A

## Additional Context
- Linear: SDK-5197 (sub-issue of SDK-5136, CloudWalk ProGuard blocker). Android core fix: rudderlabs/rudder-sdk-android#555, released as core `1.28.1`.
- Companion PR: #322 does the same for `rudder_plugin_ios` (SDK-5189).
- Root cause: `chore`-typed bump commits are not versionable by melos; both native floor bumps (#319, #320) landed as `chore` and need a `fix` commit to release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Clarified the Android SDK version pinning and its impact on release build optimization.
  * Documented that serialization-related rules are scoped appropriately to avoid unnecessary app-wide retention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->