### PR TITLE
fix: publish iOS app-hang fix to pub.dev

### DIFF
--- a/packages/plugins/rudder_plugin_ios/ios/rudder_plugin_ios.podspec
+++ b/packages/plugins/rudder_plugin_ios/ios/rudder_plugin_ios.podspec
@@ -12,6 +12,8 @@ RudderStack flutter SDK ios plugin project
   s.source_files = 'rudder_plugin_ios/Sources/rudder_plugin_ios/**/*'
   s.public_header_files = 'rudder_plugin_ios/Sources/rudder_plugin_ios/include/**/*.h'
   s.dependency 'Flutter'
+  # Floor pinned to 1.32.2: this Rudder version carries the app-hang /
+  # main-thread persistence fix, so it must reach Flutter iOS consumers.
   s.dependency "Rudder", '>= 1.32.2', '< 2.0.0'
   s.platform = :ios, '12.0'
 


### PR DESCRIPTION
## Description
Adds a versionable `fix(ios)` commit so the already-merged iOS SDK floor bump (Rudder pod `>= 1.32.2`, SDK-5189) actually ships to pub.dev.

The original bump (#319) landed on `develop` as a `chore(rudder_plugin_ios)` commit. Melos only versions `feat`/`fix`/breaking commits, so `chore` produces no version bump — meaning `rudder_plugin_ios` would not be republished and the app-hang / main-thread-persistence fix (carried by Rudder iOS `1.32.2`) would never reach Flutter consumers. This PR annotates the podspec dependency with a `fix(ios)` commit that touches the `rudder_plugin_ios` package, causing melos to patch-bump and publish it.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
- `packages/plugins/rudder_plugin_ios/ios/rudder_plugin_ios.podspec`: add a comment above the `Rudder` dependency documenting why the floor is pinned to `1.32.2`. The functional floor (`>= 1.32.2`, `< 2.0.0`) is unchanged from #319 — this commit exists to give melos a versionable change on the package.

## Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
1. Merge this PR (single commit; keep the `fix(ios):` message so melos picks it up).
2. Run `Draft new release` — confirm `rudder_plugin_ios` receives a patch bump (3.2.1 → 3.2.2) and appears in the release with a `**FIX**(ios): …` changelog entry.
3. After release, confirm the new `rudder_plugin_ios` version on pub.dev resolves `Rudder >= 1.32.2`.

## Breaking Changes
None. The dependency constraint is unchanged; this only ensures the already-intended floor is published.

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
N/A

## Additional Context
- Linear: SDK-5189.
- Companion PR: #321 does the same for `rudder_plugin_android` (SDK-5197).
- Root cause: `chore`-typed bump commits are not versionable by melos; both native floor bumps (#319, #320) landed as `chore` and need a `fix` commit to release.
