### PR TITLE
docs: sdk-3671 improve braze package score

### DIFF
--- a/packages/integrations/rudder_integration_braze_flutter/example/lib/main.dart
+++ b/packages/integrations/rudder_integration_braze_flutter/example/lib/main.dart
@@ -1,8 +1,11 @@
+import 'package:flutter/widgets.dart';
 import 'package:rudder_integration_braze_flutter/rudder_integration_braze_flutter.dart';
 import 'package:rudder_sdk_flutter/RudderController.dart';
 import 'package:rudder_sdk_flutter_platform_interface/platform.dart';
 
 void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+
   final config = RudderConfigBuilder()
     ..withDataPlaneUrl('YOUR_DATA_PLANE_URL')
     ..withFactory(RudderIntegrationBrazeFlutter());
@@ -11,4 +14,6 @@ void main() {
     'YOUR_WRITE_KEY',
     config: config.build(),
   );
+
+  runApp(const SizedBox.shrink());
 }

--- a/packages/integrations/rudder_integration_braze_flutter/example/lib/main.dart
+++ b/packages/integrations/rudder_integration_braze_flutter/example/lib/main.dart
@@ -1,0 +1,14 @@
+import 'package:rudder_integration_braze_flutter/rudder_integration_braze_flutter.dart';
+import 'package:rudder_sdk_flutter/RudderController.dart';
+import 'package:rudder_sdk_flutter_platform_interface/platform.dart';
+
+void main() {
+  final config = RudderConfigBuilder()
+    ..withDataPlaneUrl('YOUR_DATA_PLANE_URL')
+    ..withFactory(RudderIntegrationBrazeFlutter());
+
+  RudderController.instance.initialize(
+    'YOUR_WRITE_KEY',
+    config: config.build(),
+  );
+}

--- a/packages/integrations/rudder_integration_braze_flutter/lib/rudder_integration_braze_flutter.dart
+++ b/packages/integrations/rudder_integration_braze_flutter/lib/rudder_integration_braze_flutter.dart
@@ -2,10 +2,12 @@ import 'package:flutter/services.dart';
 import 'package:flutter/foundation.dart';
 import 'package:rudder_sdk_flutter_platform_interface/platform.dart';
 
+/// Adds Braze as a device-mode destination to the RudderStack Flutter SDK.
 class RudderIntegrationBrazeFlutter implements RudderIntegration {
   static const MethodChannel _channel =
       MethodChannel('rudder_integration_braze_flutter');
 
+  /// Registers the native Braze integration factory with the RudderStack SDK.
   @override
   void addFactory() {
     if (!kIsWeb) {
@@ -13,6 +15,7 @@ class RudderIntegrationBrazeFlutter implements RudderIntegration {
     }
   }
 
+  /// Returns the destination key used to identify the Braze integration.
   @override
   String getKey() {
     return "Braze";

--- a/packages/integrations/rudder_integration_braze_flutter/pubspec.yaml
+++ b/packages/integrations/rudder_integration_braze_flutter/pubspec.yaml
@@ -1,5 +1,5 @@
 name: rudder_integration_braze_flutter
-description: RudderStack Device Mode for Braze on Flutter SDK
+description: RudderStack's Flutter device-mode integration for sending mobile analytics events to Braze on Android and iOS.
 version: 2.7.1
 homepage: https://github.com/rudderlabs/rudder-sdk-flutter
 


### PR DESCRIPTION
## Summary

- expand the Braze integration package description
- document the public Braze integration API
- add a package-level initialization example

## Why

The published package currently scores 120/160 on pub.dev. These low-risk metadata and documentation changes are expected to raise the score to 150/160 without changing runtime behavior or native code.

Swift Package Manager support is intentionally deferred because it requires native iOS packaging changes and separate CocoaPods/SPM validation.

## Impact

- no breaking API changes
- no native Android or iOS changes
- no user migration required

## Validation

- `flutter analyze packages/integrations/rudder_integration_braze_flutter`
- `flutter build bundle --target=lib/rudder_integration_braze_flutter.dart`
- `dart pub publish --dry-run`
- Pana 0.23.14: 150/160 projected points

Linear: https://linear.app/rudderstack/issue/SDK-3671/feat-improve-flutter-score-for-braze

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Dart documentation comments for the Braze Flutter integration and its configuration methods.
* **Examples**
  * Updated the Flutter example entry point to properly initialize Flutter bindings before starting the Rudder integration, then launches a minimal app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->